### PR TITLE
test: cover sikesra module UI config metadata

### DIFF
--- a/packages/plugins/sikesra/tests/module-ui-config.test.ts
+++ b/packages/plugins/sikesra/tests/module-ui-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { SIKESRA_DETAIL_MODULES } from "../src/detail-modules.js";
 import { getModuleUiConfig, listModuleUiConfigs } from "../src/module-ui-config.js";
 
 describe("SIKESRA module UI config", () => {
@@ -24,8 +25,33 @@ describe("SIKESRA module UI config", () => {
 		);
 	});
 
+	it("matches detail-modules.ts field coverage and required flags for all 8 modules", () => {
+		for (const [objectTypeCode, detailModule] of Object.entries(SIKESRA_DETAIL_MODULES)) {
+			const moduleConfig = getModuleUiConfig(objectTypeCode);
+
+			expect(moduleConfig, `Missing module UI config for ${objectTypeCode}`).toBeDefined();
+			expect(moduleConfig?.detailFields.map((field) => field.key)).toEqual(detailModule.fields);
+
+			expect(
+				moduleConfig?.detailFields.filter((field) => field.required).map((field) => field.key),
+				`Required fields in ${objectTypeCode} must align exactly with detail-modules.ts`,
+			).toEqual(detailModule.requiredFields);
+
+			for (const fieldConfig of moduleConfig?.detailFields ?? []) {
+				expect(fieldConfig.label, `Field ${fieldConfig.key} in ${objectTypeCode} needs a readable label`).not.toBe(fieldConfig.key);
+			}
+		}
+	});
+
 	it("marks person-profile modules clearly for interim UX", () => {
-		for (const code of ["05", "06", "07", "08"]) {
+		const expectedHelperText = {
+			"05": "Gunakan ID profil orang yang tersedia. Pencarian/linking profil akan ditingkatkan pada tindak lanjut terpisah.",
+			"06": "Gunakan ID profil orang yang tersedia. Detail identitas sensitif tetap dimask server-side.",
+			"07": "Gunakan ID profil orang yang tersedia. Detail sensitif tidak akan ditampilkan penuh pada review umum.",
+			"08": "Gunakan ID profil orang yang tersedia. Workflow pencarian/linking profil masih akan ditingkatkan.",
+		} as const;
+
+		for (const code of ["05", "06", "07", "08"] as const) {
 			const moduleConfig = getModuleUiConfig(code);
 			const personProfileField = moduleConfig?.detailFields.find((field) => field.key === "person_profile_id");
 
@@ -33,9 +59,54 @@ describe("SIKESRA module UI config", () => {
 				expect.objectContaining({
 					label: "Person Profile",
 					required: true,
-					helperText: expect.stringContaining("profil"),
+					helperText: expectedHelperText[code],
 				}),
 			);
+		}
+	});
+
+	it("provides options for every select field", () => {
+		const expectedSubtypeCounts = {
+			"01": 8,
+			"02": 7,
+			"03": 3,
+			"04": 8,
+			"05": 3,
+			"06": 3,
+			"07": 4,
+			"08": 3,
+		} as const;
+		const expectedSelectValues: Record<string, string[]> = {
+			"01.jenis_rumah_ibadah": ["Masjid", "Musholla", "Surau", "Gereja", "Pura", "Wihara", "Klenteng", "Lainnya"],
+			"01.status_pembangunan": ["beroperasi", "dalam_pembangunan", "renovasi"],
+			"02.agama": ["Islam", "Kristen", "Katolik", "Hindu", "Buddha", "Konghucu", "Lainnya"],
+			"03.jenis_pendidikan": ["TPA/TPQ", "Pondok Pesantren", "Lainnya"],
+			"03.status_akreditasi": ["terakreditasi", "proses", "belum"],
+			"04.jenis_lks": ["BAZNAS", "PWRI", "Panti Asuhan", "Panti Yatim", "Panti Jompo", "Rukun Kematian", "Majelis Taklim", "LKS Lainnya"],
+			"05.agama": ["Islam", "Kristen", "Katolik", "Hindu", "Buddha", "Konghucu", "Lainnya"],
+			"05.status_guru": ["aktif", "tidak_aktif", "pensiun", "almarhum"],
+			"06.kategori_anak": ["yatim", "piatu", "yatim_piatu"],
+			"07.jenis_disabilitas": ["Fisik", "Intelektual", "Mental", "Sensorik"],
+			"07.tingkat_keparahan": ["ringan", "sedang", "berat"],
+			"07.alat_bantu_dibutuhkan": ["1", "0"],
+			"08.status_keterlantaran": ["terlantar", "rawan_terlantar", "mandiri_risiko"],
+			"08.status_tinggal": ["sendiri", "pasangan", "keluarga", "panti"],
+		};
+
+		for (const moduleConfig of listModuleUiConfigs()) {
+			expect(moduleConfig.subtypes.length).toBe(expectedSubtypeCounts[moduleConfig.objectTypeCode as keyof typeof expectedSubtypeCounts]);
+
+			for (const fieldConfig of moduleConfig.detailFields) {
+				if (fieldConfig.input !== "select") continue;
+				const expectedValues = expectedSelectValues[`${moduleConfig.objectTypeCode}.${fieldConfig.key}`];
+
+				expect(
+					fieldConfig.options?.length,
+					`Select field ${moduleConfig.objectTypeCode}.${fieldConfig.key} must define options`,
+				).toBeGreaterThan(0);
+				expect(fieldConfig.options?.every((option) => option.label.trim().length > 0 && option.value.trim().length > 0)).toBe(true);
+				expect(fieldConfig.options?.map((option) => option.value)).toEqual(expectedValues);
+			}
 		}
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Adds focused test coverage for `packages/plugins/sikesra/src/module-ui-config.ts` and links it to the current schema contract in `detail-modules.ts`.

Closes #281

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- `packages/plugins/sikesra`: `pnpm typecheck` passes.
- `packages/plugins/sikesra`: `pnpm test -- --runInBand` passes.
- Root `pnpm --silent lint:quick` fails before/after this change because the oxlint config references a missing `unicorn` rule (`prevent-abbreviations`).
- Root `pnpm typecheck` fails before/after this change in `packages/contentful-to-portable-text` due `rootDir`/test include errors.
- Root `pnpm test` fails before/after this change in `packages/marketplace` because `@emdash-cms/plugin-types/dist/index.js` is missing during `publish-e2e` setup.
- Root `pnpm build` passes.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4

## Screenshots / test output

- Added assertions that:
  - all 8 SIKESRA modules exist
  - `detail-modules.ts` field coverage and required flags align exactly
  - person-based modules pin exact `Person Profile` helper text
  - select fields pin exact option sets and subtype counts
