### PR TITLE
fix: validate create wizard subtype module pairing

### DIFF
--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -3,6 +3,7 @@ import { sql } from "kysely";
 import { getDetailModuleConfig } from "./detail-modules.js";
 import {
 	getEntityKindLabel,
+	hasModuleSubtype,
 	getModuleSubtypeOptions,
 	getModuleUiConfig,
 	getModuleUiFieldConfig,
@@ -1364,7 +1365,27 @@ async function handleEntityAction(
 		return buildEntityCreateForm(db, ctx);
 	}
 	if (actionId === "entities:create_draft") {
-		const created = await createDraft(db, ctx, normalizeDraftCreateForm(action.values));
+		const input = normalizeDraftCreateForm(action.values);
+		if (
+			(input.selectedSubtypeModuleCode && input.selectedSubtypeModuleCode !== input.objectTypeCode) ||
+			(input.objectTypeCode && input.objectSubtypeCode && !hasModuleSubtype(input.objectTypeCode, input.objectSubtypeCode))
+		) {
+			const createForm = await buildEntityCreateForm(db, ctx);
+			return {
+				...createForm,
+				blocks: [
+					{
+						type: "banner",
+						variant: "error",
+						title: "Subjenis Tidak Sesuai",
+						description: "Subjenis data tidak cocok dengan modul yang dipilih. Pilih subjenis yang sesuai dengan modul data SIKESRA.",
+					},
+					...createForm.blocks,
+				],
+				toast: { message: "Subjenis data tidak cocok dengan modul yang dipilih", type: "error" },
+			};
+		}
+		const created = await createDraft(db, ctx, input);
 		const detail = await buildEntityDetail(db, ctx, created.entityId);
 		return {
 			...detail,
@@ -2096,6 +2117,9 @@ function getActionEntityId(values: Record<string, unknown> | undefined) {
 function normalizeDraftCreateForm(values: Record<string, unknown> | undefined): DraftCreateInput {
 	const rawObjectTypeCode = typeof values?.objectTypeCode === "string" ? values.objectTypeCode : "";
 	const rawObjectSubtypeCode = typeof values?.objectSubtypeCode === "string" ? values.objectSubtypeCode : "";
+	const selectedSubtypeModuleCode = rawObjectSubtypeCode.includes(":")
+		? rawObjectSubtypeCode.split(":")[0] ?? undefined
+		: undefined;
 	const objectSubtypeCode = rawObjectSubtypeCode.includes(":")
 		? rawObjectSubtypeCode.split(":")[1] ?? ""
 		: rawObjectSubtypeCode;
@@ -2103,6 +2127,7 @@ function normalizeDraftCreateForm(values: Record<string, unknown> | undefined): 
 	return {
 		objectTypeCode: rawObjectTypeCode,
 		objectSubtypeCode,
+		selectedSubtypeModuleCode,
 		entityKind: moduleUi?.entityKind ?? "",
 		displayName: typeof values?.displayName === "string" ? values.displayName : "",
 		officialVillageCode: typeof values?.officialVillageCode === "string" ? values.officialVillageCode : "",

--- a/packages/plugins/sikesra/src/module-ui-config.ts
+++ b/packages/plugins/sikesra/src/module-ui-config.ts
@@ -336,6 +336,10 @@ export function getModuleSubtypeOptions(objectTypeCode?: string): Array<{ label:
 	);
 }
 
+export function hasModuleSubtype(objectTypeCode: string, subtypeCode: string): boolean {
+	return getModuleUiConfig(objectTypeCode)?.subtypes.some((subtype) => subtype.code === subtypeCode) ?? false;
+}
+
 export function getEntityKindLabel(entityKind: string): string {
 	switch (entityKind) {
 		case "person":

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -66,7 +66,7 @@ describe("SIKESRA admin entity workflow", () => {
 			values: {
 				action_id: "entities:create_draft",
 				objectTypeCode: "01",
-				objectSubtypeCode: "01",
+				objectSubtypeCode: "01:01",
 				entityKind: "building",
 				displayName: "Masjid Admin",
 				officialVillageCode: "6201011001",
@@ -83,13 +83,37 @@ describe("SIKESRA admin entity workflow", () => {
 		);
 	});
 
+	it("rejects a mismatched module and subtype pair in the create flow", async () => {
+		const response = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: {
+				action_id: "entities:create_draft",
+				objectTypeCode: "01",
+				objectSubtypeCode: "06:01",
+				entityKind: "building",
+				displayName: "Masjid Salah Subjenis",
+				officialVillageCode: "6201011001",
+			},
+		});
+
+		expect(response.toast).toEqual({
+			message: "Subjenis data tidak cocok dengan modul yang dipilih",
+			type: "error",
+		});
+		expect(response.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "banner", title: "Subjenis Tidak Sesuai" }),
+			]),
+		);
+	});
+
 	it("archives and restores an entity through admin actions", async () => {
 		await buildAdminPage(db, makeContext(), "/entities", {
 			type: "form_submit",
 			values: {
 				action_id: "entities:create_draft",
 				objectTypeCode: "01",
-				objectSubtypeCode: "01",
+				objectSubtypeCode: "01:01",
 				entityKind: "building",
 				displayName: "Masjid Arsip UI",
 				officialVillageCode: "6201011001",


### PR DESCRIPTION
## What does this PR do?

Rejects mismatched module/subtype combinations in the SIKESRA create wizard when the current block UI cannot yet narrow dependent subtype options dynamically.

Closes #282

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- This is stacked on top of #281 to keep the review atomic.
- `packages/plugins/sikesra`: `pnpm typecheck` passes.
- `packages/plugins/sikesra`: `pnpm test -- --runInBand` passes.
- Root repo blockers remain unchanged from before this PR:
  - `pnpm --silent lint:quick` fails from the oxlint config (`prevent-abbreviations` rule missing)
  - root `pnpm typecheck` fails in `packages/contentful-to-portable-text`
  - root `pnpm test` fails in `packages/marketplace`

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4

## Screenshots / test output

- Added create-flow coverage proving module `01` cannot be paired with subtype `06:01`.
- The admin flow now returns a readable banner and toast instead of creating inconsistent draft data.
