### PR TITLE
fix: block invalid or duplicate submit attempts

### DIFF
--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -61,6 +61,15 @@ interface BlockResponse {
 	toast?: { message: string; type: "success" | "error" | "info" };
 }
 
+interface EntitySubmitReadiness {
+	invalidSections: string[];
+	highRiskDuplicateCount: number;
+	documentCount: number;
+	canSubmit: boolean;
+	recommendedAction: string;
+	reasonMessage?: string;
+}
+
 // ── Admin Page Router ────────────────────────────────────────────────────────
 
 export async function buildAdminPage(
@@ -1452,6 +1461,25 @@ async function handleEntityAction(
 	if (actionId === "entities:submit_verification") {
 		const entityId = getActionEntityId(action.values);
 		if (entityId) {
+			const readiness = await getEntitySubmitReadiness(db, ctx, entityId);
+			if (!readiness.canSubmit) {
+				await auditBlockedSubmitAttempt(db, ctx, entityId, readiness.reasonMessage ?? "Entitas belum siap diajukan", {
+					invalidSections: readiness.invalidSections,
+					highRiskDuplicateCount: readiness.highRiskDuplicateCount,
+					documentCount: readiness.documentCount,
+					canSubmit: readiness.canSubmit,
+					recommendedAction: readiness.recommendedAction,
+					reasonMessage: readiness.reasonMessage,
+				});
+				const submitView = await buildEntitySubmitForm(db, ctx, entityId);
+				return {
+					...submitView,
+					toast: {
+						message: readiness.reasonMessage ?? "Entitas belum siap diajukan",
+						type: "error",
+					},
+				};
+			}
 			await submitForVerification(db, ctx, {
 				entityId,
 				note:
@@ -1956,6 +1984,7 @@ async function buildEntityReviewSummary(
 	]);
 	const runtime = buildAdminDocumentRuntime(db);
 	const documents = await getEntityDocuments(runtime, entityId, ctx);
+	const readiness = await getEntitySubmitReadiness(db, ctx, entityId, validation, documents.length, duplicatePreview);
 
 	return {
 		blocks: [
@@ -1968,7 +1997,7 @@ async function buildEntityReviewSummary(
 				items: [
 					{ label: "Kelengkapan", value: `${validation.overallPercent}%` },
 					{ label: "Dokumen", value: documents.length },
-					{ label: "Duplikat", value: duplicatePreview.length },
+					{ label: "Duplikat", value: Math.max(duplicatePreview.length, readiness.highRiskDuplicateCount) },
 					{ label: "Status", value: detail.entity.statusVerification },
 				],
 			},
@@ -2008,6 +2037,12 @@ async function buildEntityReviewSummary(
 					},
 				] as Block[])
 				: []),
+			{
+				type: "banner",
+				variant: readiness.canSubmit ? "success" : "info",
+				title: readiness.canSubmit ? "Siap Diajukan" : "Tindakan Berikutnya",
+				description: readiness.recommendedAction,
+			},
 			...(documents.length === 0
 				? ([
 					{
@@ -2037,6 +2072,29 @@ async function buildEntitySubmitForm(
 	entityId: string,
 ): Promise<BlockResponse> {
 	const detail = await getEntityDetail(db, ctx, entityId);
+	const readiness = await getEntitySubmitReadiness(db, ctx, entityId);
+	if (!readiness.canSubmit) {
+		return {
+			blocks: [
+				{ type: "header", text: "Ajukan Verifikasi" },
+				{ type: "context", text: detail.entity.displayName },
+				...buildEntityWizardSteps(entityId, 7),
+				{
+					type: "banner",
+					variant: "error",
+					title: "Belum Bisa Diajukan",
+					description: readiness.reasonMessage ?? readiness.recommendedAction,
+				},
+				{
+					type: "actions",
+					elements: [
+						{ type: "button", action_id: "entities:open_review", entityId, label: "Kembali ke Review", style: "secondary" },
+						{ type: "button", action_id: readiness.highRiskDuplicateCount > 0 ? "entities:validate" : "entities:edit_details", entityId, label: readiness.highRiskDuplicateCount > 0 ? "Tinjau Validasi & Duplikat" : "Lengkapi Detail Modul", style: "primary" },
+					],
+				},
+			],
+		};
+	}
 	return {
 		blocks: [
 			{ type: "header", text: "Ajukan Verifikasi" },
@@ -2051,6 +2109,117 @@ async function buildEntitySubmitForm(
 			},
 		],
 	};
+}
+
+async function getEntitySubmitReadiness(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	entityId: string,
+	validationResult?: Awaited<ReturnType<typeof validateEntity>>,
+	documentCount?: number,
+	duplicatePreview?: Awaited<ReturnType<typeof getEntityDuplicatePreview>>,
+): Promise<EntitySubmitReadiness> {
+	const validation = validationResult ?? (await validateEntity(db, ctx, entityId));
+	const invalidSections = validation.sections.filter((section) => !section.isValid).map((section) => section.sectionKey);
+	const highRiskDuplicateCount =
+		duplicatePreview?.filter((item) => ["high", "blocking"].includes(item.riskLevel)).length ??
+		(await countHighRiskDuplicateCandidates(db, ctx, entityId));
+	const resolvedDocumentCount =
+		documentCount ?? (await getEntityDocuments(buildAdminDocumentRuntime(db), entityId, ctx)).length;
+
+	if (invalidSections.length > 0) {
+		return {
+			invalidSections,
+			highRiskDuplicateCount,
+			documentCount: resolvedDocumentCount,
+			canSubmit: false,
+			reasonMessage: "Masih ada field wajib yang belum lengkap.",
+			recommendedAction: `Lengkapi tahap ${invalidSections.map((section) => getReadableSectionLabel(section)).join(", ")} sebelum mengajukan verifikasi.`,
+		};
+	}
+
+	if (highRiskDuplicateCount > 0) {
+		return {
+			invalidSections,
+			highRiskDuplicateCount,
+			documentCount: resolvedDocumentCount,
+			canSubmit: false,
+			reasonMessage: "Masih ada kandidat duplikat berisiko tinggi yang harus ditinjau.",
+			recommendedAction: "Tinjau kandidat duplikat berisiko tinggi pada detail atau validasi sebelum submit.",
+		};
+	}
+
+	if (resolvedDocumentCount === 0) {
+		return {
+			invalidSections,
+			highRiskDuplicateCount,
+			documentCount: resolvedDocumentCount,
+			canSubmit: true,
+			recommendedAction: "Dokumen pendukung belum ada. Tambahkan dokumen bila diwajibkan SOP, lalu ajukan verifikasi.",
+		};
+	}
+
+	return {
+		invalidSections,
+		highRiskDuplicateCount,
+		documentCount: resolvedDocumentCount,
+		canSubmit: true,
+		recommendedAction: "Semua syarat minimum sudah terpenuhi. Lanjutkan submit untuk verifikasi.",
+	};
+}
+
+async function countHighRiskDuplicateCandidates(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	entityId: string,
+): Promise<number> {
+	const result = await sql<{ total: number }>`
+		SELECT COUNT(*) AS total
+		FROM awcms_sikesra_duplicate_candidates candidate
+		JOIN awcms_sikesra_entities other_entity
+			ON other_entity.tenant_id = candidate.tenant_id
+			AND other_entity.site_id = candidate.site_id
+			AND (
+				(candidate.entity_id_a = ${entityId} AND other_entity.id = candidate.entity_id_b)
+				OR (candidate.entity_id_b = ${entityId} AND other_entity.id = candidate.entity_id_a)
+			)
+		WHERE candidate.tenant_id = ${ctx.tenantId}
+			AND candidate.site_id = ${ctx.siteId}
+			AND candidate.deleted_at IS NULL
+			AND other_entity.deleted_at IS NULL
+			AND candidate.risk_level IN ('high', 'blocking')
+			AND (candidate.entity_id_a = ${entityId} OR candidate.entity_id_b = ${entityId})
+	`.execute(db as never);
+
+	return result.rows[0]?.total ?? 0;
+}
+
+async function auditBlockedSubmitAttempt(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	entityId: string,
+	reason: string,
+	metadata: Record<string, unknown>,
+): Promise<void> {
+	try {
+		await sql`
+			INSERT INTO awcms_sikesra_audit_logs (
+				id, tenant_id, site_id, actor_id, actor_role, action,
+				resource_type, resource_id, request_id, success, reason,
+				before_json, after_json, ip_address, user_agent, created_at
+			) VALUES (
+				${`audit_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`},
+				${ctx.tenantId}, ${ctx.siteId}, ${ctx.userId},
+				${ctx.roles[0] ?? "unknown"}, 'security.access_denied',
+				'entity', ${entityId}, ${ctx.requestId}, 0, ${reason},
+				${null}, ${JSON.stringify(metadata)},
+				${ctx.ipAddress ?? null}, ${ctx.userAgent ?? null},
+				datetime('now')
+			)
+		`.execute(db as never);
+	} catch {
+		// Audit write failures should not block the admin response
+	}
 }
 
 async function buildEntityLifecycleForm(

--- a/packages/plugins/sikesra/src/services/draft.ts
+++ b/packages/plugins/sikesra/src/services/draft.ts
@@ -8,6 +8,7 @@ import { guardRoute } from "../security/route-guard.js";
 export interface DraftCreateInput {
 	objectTypeCode: string;
 	objectSubtypeCode: string;
+	selectedSubtypeModuleCode?: string;
 	entityKind: string;
 	displayName: string;
 	officialVillageCode: string;

--- a/packages/plugins/sikesra/src/services/verification.ts
+++ b/packages/plugins/sikesra/src/services/verification.ts
@@ -1,8 +1,8 @@
 import { sql } from "kysely";
-
 import { AUDIT_ACTIONS, type AuditAction } from "../security/audit.js";
 import type { SikesraRequestContext } from "../security/request-context.js";
 import { guardRoute } from "../security/route-guard.js";
+import { validateEntity } from "./draft.js";
 
 export interface VerificationSubmitInput {
 	entityId: string;
@@ -85,6 +85,39 @@ export async function submitForVerification(
 	const entity = await getEntityForVerification(db, ctx, input.entityId);
 	if (!entity)
 		return throwRouteError("NOT_FOUND", "Entity not found or not eligible for verification", 404);
+
+	const validation = await validateEntity(db, ctx, input.entityId);
+	const invalidSections = validation.sections.filter((section) => !section.isValid);
+	if (invalidSections.length > 0) {
+		await writeVerificationBlockedAudit(
+			db,
+			ctx,
+			input.entityId,
+			"Submit diblokir karena masih ada field wajib yang belum lengkap",
+			{ invalidSections: invalidSections.map((section) => section.sectionKey) },
+		);
+		return throwRouteError(
+			"VALIDATION_ERROR",
+			"Submit diblokir karena masih ada field wajib yang belum lengkap",
+			400,
+		);
+	}
+
+	const blockingDuplicates = await countHighRiskDuplicateCandidates(db, ctx, input.entityId);
+	if (blockingDuplicates > 0) {
+		await writeVerificationBlockedAudit(
+			db,
+			ctx,
+			input.entityId,
+			"Submit diblokir karena ada kandidat duplikat berisiko tinggi yang harus ditinjau",
+			{ blockingDuplicates },
+		);
+		return throwRouteError(
+			"VALIDATION_ERROR",
+			"Submit diblokir karena ada kandidat duplikat berisiko tinggi yang harus ditinjau",
+			400,
+		);
+	}
 
 	const previousStatus = entity.status_verification;
 	const nextStatus = "pending_verification";
@@ -395,6 +428,32 @@ async function getEntityForVerification(db: unknown, ctx: SikesraRequestContext,
 	return result.rows[0];
 }
 
+async function countHighRiskDuplicateCandidates(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	entityId: string,
+): Promise<number> {
+	const result = await sql<{ total: number }>`
+		SELECT COUNT(*) AS total
+		FROM awcms_sikesra_duplicate_candidates candidate
+		JOIN awcms_sikesra_entities other_entity
+			ON other_entity.tenant_id = candidate.tenant_id
+			AND other_entity.site_id = candidate.site_id
+			AND (
+				(candidate.entity_id_a = ${entityId} AND other_entity.id = candidate.entity_id_b)
+				OR (candidate.entity_id_b = ${entityId} AND other_entity.id = candidate.entity_id_a)
+			)
+		WHERE candidate.tenant_id = ${ctx.tenantId}
+			AND candidate.site_id = ${ctx.siteId}
+			AND candidate.deleted_at IS NULL
+			AND other_entity.deleted_at IS NULL
+			AND candidate.risk_level IN ('high', 'blocking')
+			AND (candidate.entity_id_a = ${entityId} OR candidate.entity_id_b = ${entityId})
+	`.execute(db as never);
+
+	return result.rows[0]?.total ?? 0;
+}
+
 function buildQueueWhereSql(ctx: SikesraRequestContext, filters: VerificationQueueFilters) {
 	const conditions = [
 		sql`entity.tenant_id = ${ctx.tenantId}`,
@@ -469,7 +528,88 @@ async function writeVerificationAudit(
 	}
 }
 
+async function writeVerificationBlockedAudit(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	entityId: string,
+	reason: string,
+	metadata: Record<string, unknown>,
+): Promise<void> {
+	try {
+		await sql`
+			INSERT INTO awcms_sikesra_audit_logs (
+				id, tenant_id, site_id, actor_id, actor_role, action,
+				resource_type, resource_id, request_id, success, reason,
+				before_json, after_json, ip_address, user_agent, created_at
+			) VALUES (
+				${`audit_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`},
+				${ctx.tenantId}, ${ctx.siteId}, ${ctx.userId},
+				${ctx.roles[0] ?? "unknown"}, ${AUDIT_ACTIONS.ACCESS_DENIED},
+				'entity', ${entityId}, ${ctx.requestId}, 0, ${reason},
+				${null}, ${JSON.stringify(metadata)},
+				${ctx.ipAddress ?? null}, ${ctx.userAgent ?? null},
+				datetime('now')
+			)
+		`.execute(db as never);
+	} catch {
+		// Audit write failures should not block the main operation
+	}
+}
+
 async function throwRouteError(code: string, message: string, status: number): Promise<never> {
-	const { PluginRouteError } = await import("emdash");
-	throw new PluginRouteError(code, message, status);
+	const mod = (await import("emdash")) as {
+		PluginRouteError?: {
+			new (code: string, message: string, status?: number, details?: unknown): Error & {
+				code: string;
+				status: number;
+			};
+			badRequest?: (message: string, details?: unknown) => Error & { code: string; status: number };
+			forbidden?: (message?: string) => Error & { code: string; status: number };
+			notFound?: (message?: string) => Error & { code: string; status: number };
+			internal?: (message?: string) => Error & { code: string; status: number };
+		};
+		default?: {
+			PluginRouteError?: {
+				new (code: string, message: string, status?: number, details?: unknown): Error & {
+					code: string;
+					status: number;
+				};
+				badRequest?: (message: string, details?: unknown) => Error & { code: string; status: number };
+				forbidden?: (message?: string) => Error & { code: string; status: number };
+				notFound?: (message?: string) => Error & { code: string; status: number };
+				internal?: (message?: string) => Error & { code: string; status: number };
+			};
+		};
+	};
+	const PluginRouteError = mod.PluginRouteError ?? mod.default?.PluginRouteError;
+
+	if (PluginRouteError?.badRequest && status === 400) {
+		const error = PluginRouteError.badRequest(message);
+		error.code = code;
+		throw error;
+	}
+	if (PluginRouteError?.forbidden && status === 403) {
+		const error = PluginRouteError.forbidden(message);
+		error.code = code;
+		throw error;
+	}
+	if (PluginRouteError?.notFound && status === 404) {
+		const error = PluginRouteError.notFound(message);
+		error.code = code;
+		throw error;
+	}
+	if (PluginRouteError?.internal && status >= 500) {
+		const error = PluginRouteError.internal(message);
+		error.code = code;
+		throw error;
+	}
+	if (PluginRouteError) {
+		throw new PluginRouteError(code, message, status);
+	}
+
+	const fallback = new Error(message) as Error & { code: string; status: number };
+	fallback.name = "PluginRouteError";
+	fallback.code = code;
+	fallback.status = status;
+	throw fallback;
 }

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -326,7 +326,33 @@ describe("SIKESRA admin entity workflow", () => {
 		expect(review.blocks).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ type: "header", text: "Review dan Submit" }),
+				expect.objectContaining({ type: "banner" }),
 				expect.objectContaining({ type: "stats" }),
+			]),
+		);
+	});
+
+	it("blocks submit form when high-risk duplicate readiness fails even after validation passes", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-submit-blocked', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Blok Submit', '6201011001', 'local-1', 'Jl. Blok', 'draft', 'draft', NULL, 'internal', 100, 'candidate', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+			INSERT INTO awcms_sikesra_rumah_ibadah_details VALUES
+			('detail-submit-blocked', 'tenant-1', 'site-1', 'entity-submit-blocked', 'Masjid', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '2026-01-01', '2026-01-02', NULL, 'admin-1', 'admin-1');
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-other', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Lain', '6201011001', 'local-1', 'Jl. Lain', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+			INSERT INTO awcms_sikesra_duplicate_candidates VALUES
+			('dup-submit-1', 'tenant-1', 'site-1', 'entity-submit-blocked', 'entity-other', '["same_name"]', 0.95, 'high', 'system', NULL, '2026-01-03', '2026-01-03', NULL, 'admin-1', 'admin-1');
+		`);
+
+		const submitView = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "block_action",
+			values: { action_id: "entities:open_submit", entityId: "entity-submit-blocked" },
+		});
+
+		expect(submitView.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "header", text: "Ajukan Verifikasi" }),
+				expect.objectContaining({ type: "banner", title: "Belum Bisa Diajukan" }),
 			]),
 		);
 	});

--- a/packages/plugins/sikesra/tests/verification.test.ts
+++ b/packages/plugins/sikesra/tests/verification.test.ts
@@ -1,0 +1,152 @@
+import Database from "better-sqlite3";
+import { Kysely, SqliteDialect, sql } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { buildTrustedRequestContext } from "../src/security/request-context.js";
+import { SIKESRA_PERMISSION_LIST } from "../src/security/permissions.js";
+import { createDraft } from "../src/services/draft.js";
+import { submitForVerification } from "../src/services/verification.js";
+
+let sqlite: Database.Database;
+let db: Kysely<unknown>;
+
+function makeContext() {
+	return buildTrustedRequestContext({
+		requestId: "req-verification",
+		tenantId: "tenant-1",
+		siteId: "site-1",
+		userId: "admin-1",
+		roles: ["admin"],
+		permissions: [...SIKESRA_PERMISSION_LIST],
+		regionScope: {},
+	});
+}
+
+beforeEach(() => {
+	sqlite = new Database(":memory:");
+	db = new Kysely({ dialect: new SqliteDialect({ database: sqlite }) });
+
+	sqlite.exec(`
+		CREATE TABLE awcms_sikesra_official_regions (code TEXT, tenant_id TEXT, site_id TEXT, name TEXT, level TEXT, parent_code TEXT, deleted_at TEXT);
+		CREATE TABLE awcms_sikesra_object_types (code TEXT, tenant_id TEXT, site_id TEXT, name TEXT, deleted_at TEXT);
+		CREATE TABLE awcms_sikesra_object_subtypes (code TEXT, type_code TEXT, tenant_id TEXT, site_id TEXT, name TEXT, deleted_at TEXT);
+		CREATE TABLE awcms_sikesra_entities (
+			id TEXT, tenant_id TEXT, site_id TEXT, sikesra_id_20 TEXT, object_type_code TEXT, object_subtype_code TEXT,
+			entity_kind TEXT, display_name TEXT, official_village_code TEXT, local_region_id TEXT, address_text TEXT,
+			status_data TEXT, status_verification TEXT, verification_level TEXT, sensitivity_level TEXT,
+			completeness_percent INTEGER, duplicate_status TEXT, source_input TEXT, created_at TEXT, updated_at TEXT,
+			verified_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT
+		);
+		CREATE TABLE awcms_sikesra_person_profiles (id TEXT);
+		CREATE TABLE awcms_sikesra_code_sequences (id TEXT, tenant_id TEXT, site_id TEXT, official_village_code TEXT, object_type_code TEXT, object_subtype_code TEXT, last_sequence INTEGER, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+		CREATE TABLE awcms_sikesra_rumah_ibadah_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, jenis_rumah_ibadah TEXT, status_pembangunan TEXT, luas_bangunan REAL, luas_tanah REAL, kapasitas_jamaah INTEGER, tahun_didirikan INTEGER, imam_nama TEXT, pengurus_nama TEXT, kegiatan_rutin TEXT, sumber_dana TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+		CREATE TABLE awcms_sikesra_duplicate_candidates (id TEXT, tenant_id TEXT, site_id TEXT, entity_id_a TEXT, entity_id_b TEXT, match_signals_json TEXT, match_score REAL, risk_level TEXT, detection_source TEXT, import_batch_id TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+		CREATE TABLE awcms_sikesra_verification_events (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, actor_id TEXT, actor_role TEXT, verification_level TEXT, action TEXT, previous_status TEXT, next_status TEXT, note TEXT, request_id TEXT, ip_address TEXT, created_at TEXT);
+		CREATE TABLE awcms_sikesra_audit_logs (id TEXT, tenant_id TEXT, site_id TEXT, actor_id TEXT, actor_role TEXT, action TEXT, resource_type TEXT, resource_id TEXT, request_id TEXT, success INTEGER, reason TEXT, before_json TEXT, after_json TEXT, ip_address TEXT, user_agent TEXT, created_at TEXT);
+	`);
+
+	sqlite.exec(`
+		INSERT INTO awcms_sikesra_official_regions VALUES ('6201011001', 'tenant-1', 'site-1', 'Desa Aman', 'village', '620101', NULL);
+		INSERT INTO awcms_sikesra_object_types VALUES ('01', 'tenant-1', 'site-1', 'Rumah Ibadah', NULL);
+		INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '01', 'tenant-1', 'site-1', 'Masjid', NULL);
+	`);
+});
+
+afterEach(async () => {
+	await db.destroy();
+	sqlite.close();
+});
+
+describe("SIKESRA verification submit gating", () => {
+	it("allows valid submit when validation passes and no high-risk duplicates exist", async () => {
+		const ctx = makeContext();
+		const created = await createDraft(db, ctx, {
+			objectTypeCode: "01",
+			objectSubtypeCode: "01",
+			entityKind: "building",
+			displayName: "Masjid Valid",
+			officialVillageCode: "6201011001",
+			initialData: { jenis_rumah_ibadah: "Masjid" },
+		});
+
+		const submitted = await submitForVerification(db, ctx, { entityId: created.entityId });
+		const entityRow = await sql<{ status_verification: string }>`
+			SELECT status_verification FROM awcms_sikesra_entities WHERE id = ${created.entityId} LIMIT 1
+		`.execute(db);
+
+		expect(submitted.nextStatus).toBe("pending_verification");
+		expect(entityRow.rows[0]?.status_verification).toBe("pending_verification");
+	});
+
+	it("blocks submit when required validation is still failing", async () => {
+		const ctx = makeContext();
+		const created = await createDraft(db, ctx, {
+			objectTypeCode: "01",
+			objectSubtypeCode: "01",
+			entityKind: "building",
+			displayName: "Masjid Belum Lengkap",
+			officialVillageCode: "6201011001",
+		});
+
+		await expect(submitForVerification(db, ctx, { entityId: created.entityId })).rejects.toThrow(
+			"Submit diblokir karena masih ada field wajib yang belum lengkap",
+		);
+
+		const auditRows = await sql<{ action: string; success: number; reason: string | null }>`
+			SELECT action, success, reason
+			FROM awcms_sikesra_audit_logs
+			WHERE resource_id = ${created.entityId}
+				AND action = 'security.access_denied'
+			ORDER BY created_at DESC
+			LIMIT 1
+		`.execute(db);
+
+		expect(auditRows.rows[0]).toEqual(
+			expect.objectContaining({
+				action: "security.access_denied",
+				success: 0,
+				reason: "Submit diblokir karena masih ada field wajib yang belum lengkap",
+			}),
+		);
+	});
+
+	it("blocks submit when high-risk duplicate candidates remain", async () => {
+		const ctx = makeContext();
+		const created = await createDraft(db, ctx, {
+			objectTypeCode: "01",
+			objectSubtypeCode: "01",
+			entityKind: "building",
+			displayName: "Masjid Duplikat",
+			officialVillageCode: "6201011001",
+			initialData: { jenis_rumah_ibadah: "Masjid" },
+		});
+
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-other', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Pembanding', '6201011001', NULL, 'Jl. Pembanding', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+			INSERT INTO awcms_sikesra_duplicate_candidates VALUES
+			('dup-high-1', 'tenant-1', 'site-1', '${created.entityId}', 'entity-other', '["same_name"]', 0.98, 'high', 'system', NULL, '2026-01-03', '2026-01-03', NULL, 'admin-1', 'admin-1');
+		`);
+
+		await expect(submitForVerification(db, ctx, { entityId: created.entityId })).rejects.toThrow(
+			"Submit diblokir karena ada kandidat duplikat berisiko tinggi yang harus ditinjau",
+		);
+
+		const auditRows = await sql<{ action: string; success: number; reason: string | null }>`
+			SELECT action, success, reason
+			FROM awcms_sikesra_audit_logs
+			WHERE resource_id = ${created.entityId}
+				AND action = 'security.access_denied'
+			ORDER BY created_at DESC
+			LIMIT 1
+		`.execute(db);
+
+		expect(auditRows.rows[0]).toEqual(
+			expect.objectContaining({
+				action: "security.access_denied",
+				success: 0,
+				reason: "Submit diblokir karena ada kandidat duplikat berisiko tinggi yang harus ditinjau",
+			}),
+		);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds explicit submit gating for SIKESRA entities so verification submit is blocked when required validation fails or live high-risk duplicate candidates still exist.

Closes #284

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- This is stacked on top of #282 to keep the review atomic.
- `packages/plugins/sikesra`: `pnpm typecheck` passes.
- `packages/plugins/sikesra`: `pnpm test -- --runInBand` passes.
- Root repo blockers remain unchanged outside SIKESRA:
  - `pnpm --silent lint:quick` fails from the oxlint config (`prevent-abbreviations` rule missing)
  - root `pnpm typecheck` fails in `packages/contentful-to-portable-text`
  - root `pnpm test` fails in `packages/marketplace`

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4

## Screenshots / test output

- Added service-level submit gating tests for:
  - valid submit
  - invalid submit blocked
  - high-risk duplicate submit blocked
- Added admin workflow coverage for blocked submit UI and review guidance.
