### PR TITLE
fix: validate create wizard subtype module pairing

### DIFF
--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -3,6 +3,7 @@ import { sql } from "kysely";
 import { getDetailModuleConfig } from "./detail-modules.js";
 import {
 	getEntityKindLabel,
+	hasModuleSubtype,
 	getModuleSubtypeOptions,
 	getModuleUiConfig,
 	getModuleUiFieldConfig,
@@ -1364,7 +1365,27 @@ async function handleEntityAction(
 		return buildEntityCreateForm(db, ctx);
 	}
 	if (actionId === "entities:create_draft") {
-		const created = await createDraft(db, ctx, normalizeDraftCreateForm(action.values));
+		const input = normalizeDraftCreateForm(action.values);
+		if (
+			(input.selectedSubtypeModuleCode && input.selectedSubtypeModuleCode !== input.objectTypeCode) ||
+			(input.objectTypeCode && input.objectSubtypeCode && !hasModuleSubtype(input.objectTypeCode, input.objectSubtypeCode))
+		) {
+			const createForm = await buildEntityCreateForm(db, ctx);
+			return {
+				...createForm,
+				blocks: [
+					{
+						type: "banner",
+						variant: "error",
+						title: "Subjenis Tidak Sesuai",
+						description: "Subjenis data tidak cocok dengan modul yang dipilih. Pilih subjenis yang sesuai dengan modul data SIKESRA.",
+					},
+					...createForm.blocks,
+				],
+				toast: { message: "Subjenis data tidak cocok dengan modul yang dipilih", type: "error" },
+			};
+		}
+		const created = await createDraft(db, ctx, input);
 		const detail = await buildEntityDetail(db, ctx, created.entityId);
 		return {
 			...detail,
@@ -2096,6 +2117,9 @@ function getActionEntityId(values: Record<string, unknown> | undefined) {
 function normalizeDraftCreateForm(values: Record<string, unknown> | undefined): DraftCreateInput {
 	const rawObjectTypeCode = typeof values?.objectTypeCode === "string" ? values.objectTypeCode : "";
 	const rawObjectSubtypeCode = typeof values?.objectSubtypeCode === "string" ? values.objectSubtypeCode : "";
+	const selectedSubtypeModuleCode = rawObjectSubtypeCode.includes(":")
+		? rawObjectSubtypeCode.split(":")[0] ?? undefined
+		: undefined;
 	const objectSubtypeCode = rawObjectSubtypeCode.includes(":")
 		? rawObjectSubtypeCode.split(":")[1] ?? ""
 		: rawObjectSubtypeCode;
@@ -2103,6 +2127,7 @@ function normalizeDraftCreateForm(values: Record<string, unknown> | undefined): 
 	return {
 		objectTypeCode: rawObjectTypeCode,
 		objectSubtypeCode,
+		selectedSubtypeModuleCode,
 		entityKind: moduleUi?.entityKind ?? "",
 		displayName: typeof values?.displayName === "string" ? values.displayName : "",
 		officialVillageCode: typeof values?.officialVillageCode === "string" ? values.officialVillageCode : "",

--- a/packages/plugins/sikesra/src/module-ui-config.ts
+++ b/packages/plugins/sikesra/src/module-ui-config.ts
@@ -336,6 +336,10 @@ export function getModuleSubtypeOptions(objectTypeCode?: string): Array<{ label:
 	);
 }
 
+export function hasModuleSubtype(objectTypeCode: string, subtypeCode: string): boolean {
+	return getModuleUiConfig(objectTypeCode)?.subtypes.some((subtype) => subtype.code === subtypeCode) ?? false;
+}
+
 export function getEntityKindLabel(entityKind: string): string {
 	switch (entityKind) {
 		case "person":

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -66,7 +66,7 @@ describe("SIKESRA admin entity workflow", () => {
 			values: {
 				action_id: "entities:create_draft",
 				objectTypeCode: "01",
-				objectSubtypeCode: "01",
+				objectSubtypeCode: "01:01",
 				entityKind: "building",
 				displayName: "Masjid Admin",
 				officialVillageCode: "6201011001",
@@ -83,13 +83,37 @@ describe("SIKESRA admin entity workflow", () => {
 		);
 	});
 
+	it("rejects a mismatched module and subtype pair in the create flow", async () => {
+		const response = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: {
+				action_id: "entities:create_draft",
+				objectTypeCode: "01",
+				objectSubtypeCode: "06:01",
+				entityKind: "building",
+				displayName: "Masjid Salah Subjenis",
+				officialVillageCode: "6201011001",
+			},
+		});
+
+		expect(response.toast).toEqual({
+			message: "Subjenis data tidak cocok dengan modul yang dipilih",
+			type: "error",
+		});
+		expect(response.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "banner", title: "Subjenis Tidak Sesuai" }),
+			]),
+		);
+	});
+
 	it("archives and restores an entity through admin actions", async () => {
 		await buildAdminPage(db, makeContext(), "/entities", {
 			type: "form_submit",
 			values: {
 				action_id: "entities:create_draft",
 				objectTypeCode: "01",
-				objectSubtypeCode: "01",
+				objectSubtypeCode: "01:01",
 				entityKind: "building",
 				displayName: "Masjid Arsip UI",
 				officialVillageCode: "6201011001",

--- a/packages/plugins/sikesra/tests/module-ui-config.test.ts
+++ b/packages/plugins/sikesra/tests/module-ui-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { SIKESRA_DETAIL_MODULES } from "../src/detail-modules.js";
 import { getModuleUiConfig, listModuleUiConfigs } from "../src/module-ui-config.js";
 
 describe("SIKESRA module UI config", () => {
@@ -24,8 +25,33 @@ describe("SIKESRA module UI config", () => {
 		);
 	});
 
+	it("matches detail-modules.ts field coverage and required flags for all 8 modules", () => {
+		for (const [objectTypeCode, detailModule] of Object.entries(SIKESRA_DETAIL_MODULES)) {
+			const moduleConfig = getModuleUiConfig(objectTypeCode);
+
+			expect(moduleConfig, `Missing module UI config for ${objectTypeCode}`).toBeDefined();
+			expect(moduleConfig?.detailFields.map((field) => field.key)).toEqual(detailModule.fields);
+
+			expect(
+				moduleConfig?.detailFields.filter((field) => field.required).map((field) => field.key),
+				`Required fields in ${objectTypeCode} must align exactly with detail-modules.ts`,
+			).toEqual(detailModule.requiredFields);
+
+			for (const fieldConfig of moduleConfig?.detailFields ?? []) {
+				expect(fieldConfig.label, `Field ${fieldConfig.key} in ${objectTypeCode} needs a readable label`).not.toBe(fieldConfig.key);
+			}
+		}
+	});
+
 	it("marks person-profile modules clearly for interim UX", () => {
-		for (const code of ["05", "06", "07", "08"]) {
+		const expectedHelperText = {
+			"05": "Gunakan ID profil orang yang tersedia. Pencarian/linking profil akan ditingkatkan pada tindak lanjut terpisah.",
+			"06": "Gunakan ID profil orang yang tersedia. Detail identitas sensitif tetap dimask server-side.",
+			"07": "Gunakan ID profil orang yang tersedia. Detail sensitif tidak akan ditampilkan penuh pada review umum.",
+			"08": "Gunakan ID profil orang yang tersedia. Workflow pencarian/linking profil masih akan ditingkatkan.",
+		} as const;
+
+		for (const code of ["05", "06", "07", "08"] as const) {
 			const moduleConfig = getModuleUiConfig(code);
 			const personProfileField = moduleConfig?.detailFields.find((field) => field.key === "person_profile_id");
 
@@ -33,9 +59,54 @@ describe("SIKESRA module UI config", () => {
 				expect.objectContaining({
 					label: "Person Profile",
 					required: true,
-					helperText: expect.stringContaining("profil"),
+					helperText: expectedHelperText[code],
 				}),
 			);
+		}
+	});
+
+	it("provides options for every select field", () => {
+		const expectedSubtypeCounts = {
+			"01": 8,
+			"02": 7,
+			"03": 3,
+			"04": 8,
+			"05": 3,
+			"06": 3,
+			"07": 4,
+			"08": 3,
+		} as const;
+		const expectedSelectValues: Record<string, string[]> = {
+			"01.jenis_rumah_ibadah": ["Masjid", "Musholla", "Surau", "Gereja", "Pura", "Wihara", "Klenteng", "Lainnya"],
+			"01.status_pembangunan": ["beroperasi", "dalam_pembangunan", "renovasi"],
+			"02.agama": ["Islam", "Kristen", "Katolik", "Hindu", "Buddha", "Konghucu", "Lainnya"],
+			"03.jenis_pendidikan": ["TPA/TPQ", "Pondok Pesantren", "Lainnya"],
+			"03.status_akreditasi": ["terakreditasi", "proses", "belum"],
+			"04.jenis_lks": ["BAZNAS", "PWRI", "Panti Asuhan", "Panti Yatim", "Panti Jompo", "Rukun Kematian", "Majelis Taklim", "LKS Lainnya"],
+			"05.agama": ["Islam", "Kristen", "Katolik", "Hindu", "Buddha", "Konghucu", "Lainnya"],
+			"05.status_guru": ["aktif", "tidak_aktif", "pensiun", "almarhum"],
+			"06.kategori_anak": ["yatim", "piatu", "yatim_piatu"],
+			"07.jenis_disabilitas": ["Fisik", "Intelektual", "Mental", "Sensorik"],
+			"07.tingkat_keparahan": ["ringan", "sedang", "berat"],
+			"07.alat_bantu_dibutuhkan": ["1", "0"],
+			"08.status_keterlantaran": ["terlantar", "rawan_terlantar", "mandiri_risiko"],
+			"08.status_tinggal": ["sendiri", "pasangan", "keluarga", "panti"],
+		};
+
+		for (const moduleConfig of listModuleUiConfigs()) {
+			expect(moduleConfig.subtypes.length).toBe(expectedSubtypeCounts[moduleConfig.objectTypeCode as keyof typeof expectedSubtypeCounts]);
+
+			for (const fieldConfig of moduleConfig.detailFields) {
+				if (fieldConfig.input !== "select") continue;
+				const expectedValues = expectedSelectValues[`${moduleConfig.objectTypeCode}.${fieldConfig.key}`];
+
+				expect(
+					fieldConfig.options?.length,
+					`Select field ${moduleConfig.objectTypeCode}.${fieldConfig.key} must define options`,
+				).toBeGreaterThan(0);
+				expect(fieldConfig.options?.every((option) => option.label.trim().length > 0 && option.value.trim().length > 0)).toBe(true);
+				expect(fieldConfig.options?.map((option) => option.value)).toEqual(expectedValues);
+			}
 		}
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Restores the resolved `#282` delta onto `main` after the previous stacked PR auto-closed when its base branch merged. This keeps the create wizard from accepting mismatched module/subtype pairs.

Closes #282

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- `packages/plugins/sikesra`: `pnpm typecheck` passes.
- `packages/plugins/sikesra`: `pnpm test -- --runInBand` passes.
- Root repo blockers remain unchanged outside SIKESRA.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4
