### PR TITLE
feat: improve document step upload handoff

### DIFF
--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -3,6 +3,7 @@ import { sql } from "kysely";
 import { getDetailModuleConfig } from "./detail-modules.js";
 import {
 	getEntityKindLabel,
+	hasModuleSubtype,
 	getModuleSubtypeOptions,
 	getModuleUiConfig,
 	getModuleUiFieldConfig,
@@ -1364,7 +1365,27 @@ async function handleEntityAction(
 		return buildEntityCreateForm(db, ctx);
 	}
 	if (actionId === "entities:create_draft") {
-		const created = await createDraft(db, ctx, normalizeDraftCreateForm(action.values));
+		const input = normalizeDraftCreateForm(action.values);
+		if (
+			(input.selectedSubtypeModuleCode && input.selectedSubtypeModuleCode !== input.objectTypeCode) ||
+			(input.objectTypeCode && input.objectSubtypeCode && !hasModuleSubtype(input.objectTypeCode, input.objectSubtypeCode))
+		) {
+			const createForm = await buildEntityCreateForm(db, ctx);
+			return {
+				...createForm,
+				blocks: [
+					{
+						type: "banner",
+						variant: "error",
+						title: "Subjenis Tidak Sesuai",
+						description: "Subjenis data tidak cocok dengan modul yang dipilih. Pilih subjenis yang sesuai dengan modul data SIKESRA.",
+					},
+					...createForm.blocks,
+				],
+				toast: { message: "Subjenis data tidak cocok dengan modul yang dipilih", type: "error" },
+			};
+		}
+		const created = await createDraft(db, ctx, input);
 		const detail = await buildEntityDetail(db, ctx, created.entityId);
 		return {
 			...detail,
@@ -2096,6 +2117,9 @@ function getActionEntityId(values: Record<string, unknown> | undefined) {
 function normalizeDraftCreateForm(values: Record<string, unknown> | undefined): DraftCreateInput {
 	const rawObjectTypeCode = typeof values?.objectTypeCode === "string" ? values.objectTypeCode : "";
 	const rawObjectSubtypeCode = typeof values?.objectSubtypeCode === "string" ? values.objectSubtypeCode : "";
+	const selectedSubtypeModuleCode = rawObjectSubtypeCode.includes(":")
+		? rawObjectSubtypeCode.split(":")[0] ?? undefined
+		: undefined;
 	const objectSubtypeCode = rawObjectSubtypeCode.includes(":")
 		? rawObjectSubtypeCode.split(":")[1] ?? ""
 		: rawObjectSubtypeCode;
@@ -2103,6 +2127,7 @@ function normalizeDraftCreateForm(values: Record<string, unknown> | undefined): 
 	return {
 		objectTypeCode: rawObjectTypeCode,
 		objectSubtypeCode,
+		selectedSubtypeModuleCode,
 		entityKind: moduleUi?.entityKind ?? "",
 		displayName: typeof values?.displayName === "string" ? values.displayName : "",
 		officialVillageCode: typeof values?.officialVillageCode === "string" ? values.officialVillageCode : "",

--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -61,6 +61,15 @@ interface BlockResponse {
 	toast?: { message: string; type: "success" | "error" | "info" };
 }
 
+interface EntitySubmitReadiness {
+	invalidSections: string[];
+	highRiskDuplicateCount: number;
+	documentCount: number;
+	canSubmit: boolean;
+	recommendedAction: string;
+	reasonMessage?: string;
+}
+
 // ── Admin Page Router ────────────────────────────────────────────────────────
 
 export async function buildAdminPage(
@@ -1452,6 +1461,25 @@ async function handleEntityAction(
 	if (actionId === "entities:submit_verification") {
 		const entityId = getActionEntityId(action.values);
 		if (entityId) {
+			const readiness = await getEntitySubmitReadiness(db, ctx, entityId);
+			if (!readiness.canSubmit) {
+				await auditBlockedSubmitAttempt(db, ctx, entityId, readiness.reasonMessage ?? "Entitas belum siap diajukan", {
+					invalidSections: readiness.invalidSections,
+					highRiskDuplicateCount: readiness.highRiskDuplicateCount,
+					documentCount: readiness.documentCount,
+					canSubmit: readiness.canSubmit,
+					recommendedAction: readiness.recommendedAction,
+					reasonMessage: readiness.reasonMessage,
+				});
+				const submitView = await buildEntitySubmitForm(db, ctx, entityId);
+				return {
+					...submitView,
+					toast: {
+						message: readiness.reasonMessage ?? "Entitas belum siap diajukan",
+						type: "error",
+					},
+				};
+			}
 			await submitForVerification(db, ctx, {
 				entityId,
 				note:
@@ -1956,6 +1984,7 @@ async function buildEntityReviewSummary(
 	]);
 	const runtime = buildAdminDocumentRuntime(db);
 	const documents = await getEntityDocuments(runtime, entityId, ctx);
+	const readiness = await getEntitySubmitReadiness(db, ctx, entityId, validation, documents.length, duplicatePreview);
 
 	return {
 		blocks: [
@@ -1968,7 +1997,7 @@ async function buildEntityReviewSummary(
 				items: [
 					{ label: "Kelengkapan", value: `${validation.overallPercent}%` },
 					{ label: "Dokumen", value: documents.length },
-					{ label: "Duplikat", value: duplicatePreview.length },
+					{ label: "Duplikat", value: Math.max(duplicatePreview.length, readiness.highRiskDuplicateCount) },
 					{ label: "Status", value: detail.entity.statusVerification },
 				],
 			},
@@ -2008,6 +2037,12 @@ async function buildEntityReviewSummary(
 					},
 				] as Block[])
 				: []),
+			{
+				type: "banner",
+				variant: readiness.canSubmit ? "success" : "info",
+				title: readiness.canSubmit ? "Siap Diajukan" : "Tindakan Berikutnya",
+				description: readiness.recommendedAction,
+			},
 			...(documents.length === 0
 				? ([
 					{
@@ -2037,6 +2072,29 @@ async function buildEntitySubmitForm(
 	entityId: string,
 ): Promise<BlockResponse> {
 	const detail = await getEntityDetail(db, ctx, entityId);
+	const readiness = await getEntitySubmitReadiness(db, ctx, entityId);
+	if (!readiness.canSubmit) {
+		return {
+			blocks: [
+				{ type: "header", text: "Ajukan Verifikasi" },
+				{ type: "context", text: detail.entity.displayName },
+				...buildEntityWizardSteps(entityId, 7),
+				{
+					type: "banner",
+					variant: "error",
+					title: "Belum Bisa Diajukan",
+					description: readiness.reasonMessage ?? readiness.recommendedAction,
+				},
+				{
+					type: "actions",
+					elements: [
+						{ type: "button", action_id: "entities:open_review", entityId, label: "Kembali ke Review", style: "secondary" },
+						{ type: "button", action_id: readiness.highRiskDuplicateCount > 0 ? "entities:validate" : "entities:edit_details", entityId, label: readiness.highRiskDuplicateCount > 0 ? "Tinjau Validasi & Duplikat" : "Lengkapi Detail Modul", style: "primary" },
+					],
+				},
+			],
+		};
+	}
 	return {
 		blocks: [
 			{ type: "header", text: "Ajukan Verifikasi" },
@@ -2051,6 +2109,117 @@ async function buildEntitySubmitForm(
 			},
 		],
 	};
+}
+
+async function getEntitySubmitReadiness(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	entityId: string,
+	validationResult?: Awaited<ReturnType<typeof validateEntity>>,
+	documentCount?: number,
+	duplicatePreview?: Awaited<ReturnType<typeof getEntityDuplicatePreview>>,
+): Promise<EntitySubmitReadiness> {
+	const validation = validationResult ?? (await validateEntity(db, ctx, entityId));
+	const invalidSections = validation.sections.filter((section) => !section.isValid).map((section) => section.sectionKey);
+	const highRiskDuplicateCount =
+		duplicatePreview?.filter((item) => ["high", "blocking"].includes(item.riskLevel)).length ??
+		(await countHighRiskDuplicateCandidates(db, ctx, entityId));
+	const resolvedDocumentCount =
+		documentCount ?? (await getEntityDocuments(buildAdminDocumentRuntime(db), entityId, ctx)).length;
+
+	if (invalidSections.length > 0) {
+		return {
+			invalidSections,
+			highRiskDuplicateCount,
+			documentCount: resolvedDocumentCount,
+			canSubmit: false,
+			reasonMessage: "Masih ada field wajib yang belum lengkap.",
+			recommendedAction: `Lengkapi tahap ${invalidSections.map((section) => getReadableSectionLabel(section)).join(", ")} sebelum mengajukan verifikasi.`,
+		};
+	}
+
+	if (highRiskDuplicateCount > 0) {
+		return {
+			invalidSections,
+			highRiskDuplicateCount,
+			documentCount: resolvedDocumentCount,
+			canSubmit: false,
+			reasonMessage: "Masih ada kandidat duplikat berisiko tinggi yang harus ditinjau.",
+			recommendedAction: "Tinjau kandidat duplikat berisiko tinggi pada detail atau validasi sebelum submit.",
+		};
+	}
+
+	if (resolvedDocumentCount === 0) {
+		return {
+			invalidSections,
+			highRiskDuplicateCount,
+			documentCount: resolvedDocumentCount,
+			canSubmit: true,
+			recommendedAction: "Dokumen pendukung belum ada. Tambahkan dokumen bila diwajibkan SOP, lalu ajukan verifikasi.",
+		};
+	}
+
+	return {
+		invalidSections,
+		highRiskDuplicateCount,
+		documentCount: resolvedDocumentCount,
+		canSubmit: true,
+		recommendedAction: "Semua syarat minimum sudah terpenuhi. Lanjutkan submit untuk verifikasi.",
+	};
+}
+
+async function countHighRiskDuplicateCandidates(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	entityId: string,
+): Promise<number> {
+	const result = await sql<{ total: number }>`
+		SELECT COUNT(*) AS total
+		FROM awcms_sikesra_duplicate_candidates candidate
+		JOIN awcms_sikesra_entities other_entity
+			ON other_entity.tenant_id = candidate.tenant_id
+			AND other_entity.site_id = candidate.site_id
+			AND (
+				(candidate.entity_id_a = ${entityId} AND other_entity.id = candidate.entity_id_b)
+				OR (candidate.entity_id_b = ${entityId} AND other_entity.id = candidate.entity_id_a)
+			)
+		WHERE candidate.tenant_id = ${ctx.tenantId}
+			AND candidate.site_id = ${ctx.siteId}
+			AND candidate.deleted_at IS NULL
+			AND other_entity.deleted_at IS NULL
+			AND candidate.risk_level IN ('high', 'blocking')
+			AND (candidate.entity_id_a = ${entityId} OR candidate.entity_id_b = ${entityId})
+	`.execute(db as never);
+
+	return result.rows[0]?.total ?? 0;
+}
+
+async function auditBlockedSubmitAttempt(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	entityId: string,
+	reason: string,
+	metadata: Record<string, unknown>,
+): Promise<void> {
+	try {
+		await sql`
+			INSERT INTO awcms_sikesra_audit_logs (
+				id, tenant_id, site_id, actor_id, actor_role, action,
+				resource_type, resource_id, request_id, success, reason,
+				before_json, after_json, ip_address, user_agent, created_at
+			) VALUES (
+				${`audit_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`},
+				${ctx.tenantId}, ${ctx.siteId}, ${ctx.userId},
+				${ctx.roles[0] ?? "unknown"}, 'security.access_denied',
+				'entity', ${entityId}, ${ctx.requestId}, 0, ${reason},
+				${null}, ${JSON.stringify(metadata)},
+				${ctx.ipAddress ?? null}, ${ctx.userAgent ?? null},
+				datetime('now')
+			)
+		`.execute(db as never);
+	} catch {
+		// Audit write failures should not block the admin response
+	}
 }
 
 async function buildEntityLifecycleForm(

--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -9,9 +9,12 @@ import {
 	getModuleUiFieldConfig,
 	listModuleUiConfigs,
 } from "./module-ui-config.js";
+import { SIKESRA_API_BASE } from "./shared.js";
 import {
 	completeUpload,
+	estimateBase64SizeBytes,
 	generateUploadUrl,
+	guessMimeTypeFromFilename,
 	getEntityDocuments,
 	validateUploadInput,
 	type CompleteUploadInput,
@@ -69,6 +72,10 @@ interface EntitySubmitReadiness {
 	recommendedAction: string;
 	reasonMessage?: string;
 }
+
+interface AdminDocumentRegisterInput
+	extends GenerateUploadUrlInput,
+		Pick<CompleteUploadInput, "entityId" | "documentType" | "checksumSha256" | "contentBase64"> {}
 
 // ── Admin Page Router ────────────────────────────────────────────────────────
 
@@ -1431,10 +1438,42 @@ async function handleEntityAction(
 		if (entityId) return buildEntityReviewSummary(db, ctx, entityId);
 	}
 	if (actionId === "entities:document_register") {
-		const input = normalizeDocumentRegisterForm(action.values);
-		await registerEntityDocument(db, ctx, input);
-		const step = await buildEntityDocumentStep(db, ctx, input.entityId);
-		return { ...step, toast: { message: "Dokumen berhasil dicatat", type: "success" } };
+		try {
+			const input = normalizeDocumentRegisterForm(action.values);
+			const registered = await registerEntityDocument(db, ctx, input);
+			if (registered.mode === "prepared") {
+				return buildPreparedDocumentUploadStep(db, ctx, input.entityId, {
+					entityId: input.entityId,
+					fileName: input.fileName,
+					documentType: input.documentType,
+					classification: input.classification,
+					mimeType: input.mimeType,
+					fileObjectId: registered.upload.fileObjectId,
+				});
+			}
+			const step = await buildEntityDocumentStep(db, ctx, input.entityId);
+			return { ...step, toast: { message: "Dokumen berhasil dicatat", type: "success" } };
+		} catch (error) {
+			const entityId = typeof action.values?.entityId === "string" ? action.values.entityId : "";
+			const step = entityId ? await buildEntityDocumentStep(db, ctx, entityId) : { blocks: [] };
+			const rawMessage = error instanceof Error ? error.message : "Dokumen tidak valid";
+			const message = rawMessage === "DOCUMENT_REGISTER_INPUT_REQUIRED"
+				? "Nama file, jenis dokumen, dan entity ID wajib diisi."
+				: rawMessage.replace(/^DOCUMENT_REGISTER_INVALID:\s*/, "");
+			return {
+				...step,
+				blocks: [
+					{
+						type: "banner",
+						variant: "error",
+						title: "Dokumen Tidak Valid",
+						description: message,
+					},
+					...step.blocks,
+				],
+				toast: { message: message || "Dokumen tidak valid", type: "error" },
+			};
+		}
 	}
 	if (actionId === "entities:update_section") {
 		const input = normalizeDraftUpdateForm(action.values);
@@ -1907,13 +1946,28 @@ async function buildEntityDocumentStep(
 			...buildEntityWizardSteps(entityId, 4),
 			{ type: "divider" },
 			{
+				type: "banner",
+				variant: "info",
+				title: "Workflow Upload Dokumen",
+				description: "MIME type diturunkan dari nama file dan ukuran dihitung dari payload file yang diberikan di shell ini. Jika shell belum bisa unggah file langsung, gunakan handoff API upload yang aman tanpa mengisi metadata teknis secara manual.",
+			},
+			{
 				type: "form",
 				fields: [
 					{ type: "text_input", action_id: "entityId", label: "Entity ID", value: entityId },
 					{ type: "text_input", action_id: "fileName", label: "Nama File", placeholder: "ktp.pdf" },
-					{ type: "text_input", action_id: "documentType", label: "Jenis Dokumen", placeholder: "ktp / kk / surat_keterangan" },
-					{ type: "text_input", action_id: "mimeType", label: "MIME Type", value: "application/pdf" },
-					{ type: "text_input", action_id: "sizeBytes", label: "Ukuran (bytes)", value: "1024" },
+					{
+						type: "select",
+						action_id: "documentType",
+						label: "Jenis Dokumen",
+						options: [
+							{ label: "KTP", value: "ktp" },
+							{ label: "KK", value: "kk" },
+							{ label: "Surat Keterangan", value: "surat_keterangan" },
+							{ label: "Foto Lokasi", value: "foto_lokasi" },
+							{ label: "Lainnya", value: "lainnya" },
+						],
+					},
 					{
 						type: "select",
 						action_id: "classification",
@@ -1924,9 +1978,16 @@ async function buildEntityDocumentStep(
 							{ label: "Highly Restricted", value: "highly_restricted" },
 						],
 					},
+					{
+						type: "text_input",
+						action_id: "contentBase64",
+						label: "Konten File Base64 (opsional untuk shell ini)",
+						multiline: true,
+						placeholder: "Tempel base64 file untuk simulasi/testing, atau kosongkan untuk menyiapkan upload URL.",
+					},
 					{ type: "text_input", action_id: "checksumSha256", label: "Checksum SHA256", placeholder: "opsional" },
 				],
-				submit: { label: "Catat Dokumen", action_id: "entities:document_register" },
+				submit: { label: "Siapkan / Catat Dokumen", action_id: "entities:document_register" },
 			},
 			{ type: "divider" },
 			...(documents.length === 0
@@ -2329,11 +2390,13 @@ function normalizeEntityLifecycleForm(values: Record<string, unknown> | undefine
 }
 
 function normalizeDocumentRegisterForm(values: Record<string, unknown> | undefined):
-	GenerateUploadUrlInput &
-	Pick<CompleteUploadInput, "entityId" | "documentType" | "checksumSha256"> {
+	AdminDocumentRegisterInput {
 	const fileName = typeof values?.fileName === "string" ? values.fileName : "";
-	const mimeType = typeof values?.mimeType === "string" ? values.mimeType : "application/pdf";
-	const sizeBytesRaw = typeof values?.sizeBytes === "string" ? Number(values.sizeBytes) : values?.sizeBytes;
+	const mimeType = guessMimeTypeFromFilename(fileName) ?? "";
+	const contentBase64 =
+		typeof values?.contentBase64 === "string" && values.contentBase64.trim()
+			? values.contentBase64.trim()
+			: undefined;
 	const classification =
 		typeof values?.classification === "string"
 			? (values.classification as DocumentClassification)
@@ -2343,16 +2406,18 @@ function normalizeDocumentRegisterForm(values: Record<string, unknown> | undefin
 	const input = {
 		fileName,
 		mimeType,
-		sizeBytes: typeof sizeBytesRaw === "number" && Number.isFinite(sizeBytesRaw) ? sizeBytesRaw : 0,
+		sizeBytes: contentBase64 ? estimateBase64SizeBytes(contentBase64) : 0,
 		classification,
 		entityId,
 		documentType,
+		contentBase64,
 		checksumSha256:
 			typeof values?.checksumSha256 === "string" && values.checksumSha256
 				? values.checksumSha256
 				: undefined,
 	};
 	if (!entityId || !documentType) throw new Error("DOCUMENT_REGISTER_INPUT_REQUIRED");
+	if (!mimeType) throw new Error("DOCUMENT_REGISTER_INVALID: Tipe file belum didukung dari nama file yang diberikan.");
 	const errors = validateUploadInput(input);
 	if (errors.length > 0) throw new Error(`DOCUMENT_REGISTER_INVALID: ${errors.join("; ")}`);
 	return input;
@@ -2361,9 +2426,16 @@ function normalizeDocumentRegisterForm(values: Record<string, unknown> | undefin
 async function registerEntityDocument(
 	db: unknown,
 	ctx: SikesraRequestContext,
-	input: GenerateUploadUrlInput & Pick<CompleteUploadInput, "entityId" | "documentType" | "checksumSha256">,
-) {
+	input: AdminDocumentRegisterInput,
+): Promise<{ mode: "prepared" | "completed"; upload: UploadUrlResponse }> {
 	const runtime = buildAdminDocumentRuntime(db);
+	if (!input.contentBase64) {
+		const upload = await generateUploadUrl(input, ctx, runtime);
+		return {
+			mode: "prepared",
+			upload,
+		};
+	}
 	const upload = await generateUploadUrl(input, ctx, runtime);
 	await completeUpload(
 		{
@@ -2371,6 +2443,7 @@ async function registerEntityDocument(
 			entityId: input.entityId,
 			documentType: input.documentType,
 			classification: input.classification,
+			contentBase64: input.contentBase64,
 			checksumSha256: input.checksumSha256,
 			originalFilename: input.fileName,
 			mimeType: input.mimeType,
@@ -2379,7 +2452,47 @@ async function registerEntityDocument(
 		ctx,
 		runtime,
 	);
-	return upload;
+	return { mode: "completed", upload };
+}
+
+async function buildPreparedDocumentUploadStep(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	entityId: string,
+	prepared: {
+		entityId: string;
+		fileName: string;
+		documentType: string;
+		classification: string;
+		mimeType: string;
+		fileObjectId: string;
+	},
+): Promise<BlockResponse> {
+	const step = await buildEntityDocumentStep(db, ctx, entityId);
+	return {
+		blocks: [
+			{
+				type: "banner",
+				variant: "info",
+				title: "Handoff Upload API",
+				description: "Shell admin ini belum mengunggah file biner langsung. Gunakan fileObjectId berikut pada klien/API yang mendukung upload, lalu panggil endpoint complete dengan MIME type, sizeBytes, dan payload file sebenarnya untuk menyimpan metadata akhir dan audit.",
+			},
+			{
+				type: "fields",
+				fields: [
+					{ label: "Entity ID", value: prepared.entityId },
+					{ label: "Nama File", value: prepared.fileName },
+					{ label: "Jenis Dokumen", value: prepared.documentType },
+					{ label: "Klasifikasi", value: prepared.classification },
+					{ label: "MIME Type", value: prepared.mimeType },
+					{ label: "File Object ID", value: prepared.fileObjectId },
+					{ label: "API Complete Upload", value: `${SIKESRA_API_BASE}/v1/documents/complete` },
+				],
+			},
+			...step.blocks,
+		],
+				toast: { message: "Handoff upload siap digunakan", type: "info" },
+			};
 }
 
 function buildModuleDetailFields(

--- a/packages/plugins/sikesra/src/document.ts
+++ b/packages/plugins/sikesra/src/document.ts
@@ -122,6 +122,17 @@ export interface DocumentStorageContext {
 	};
 }
 
+const FILENAME_MIME_MAP: Record<string, string> = {
+	".pdf": "application/pdf",
+	".jpg": "image/jpeg",
+	".jpeg": "image/jpeg",
+	".png": "image/png",
+	".doc": "application/msword",
+	".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+	".xls": "application/vnd.ms-excel",
+	".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+};
+
 const ALLOWED_MIME_TYPES = new Set([
 	"application/pdf",
 	"image/jpeg",
@@ -152,6 +163,19 @@ export function validateUploadInput(input: GenerateUploadUrlInput): string[] {
 		errors.push(`Invalid classification: ${input.classification}.`);
 	}
 	return errors;
+}
+
+export function guessMimeTypeFromFilename(fileName: string): string | null {
+	const normalized = fileName.trim().toLowerCase();
+	const extension = normalized.includes(".") ? normalized.slice(normalized.lastIndexOf(".")) : "";
+	return FILENAME_MIME_MAP[extension] ?? null;
+}
+
+export function estimateBase64SizeBytes(contentBase64: string): number {
+	const normalized = contentBase64.replace(/\s+/g, "");
+	if (!normalized) return 0;
+	const padding = normalized.endsWith("==") ? 2 : normalized.endsWith("=") ? 1 : 0;
+	return Math.max(0, Math.floor((normalized.length * 3) / 4) - padding);
 }
 
 export async function generateUploadUrl(
@@ -188,7 +212,7 @@ export async function generateUploadUrl(
 	}
 
 	return {
-		uploadUrl: `/_emdash/api/plugins/sikesra/v1/documents/${fileObjectId}/upload`,
+		uploadUrl: `/_emdash/api/plugins/sikesra/v1/documents/complete`,
 		fileObjectId,
 	};
 }

--- a/packages/plugins/sikesra/src/module-ui-config.ts
+++ b/packages/plugins/sikesra/src/module-ui-config.ts
@@ -336,6 +336,10 @@ export function getModuleSubtypeOptions(objectTypeCode?: string): Array<{ label:
 	);
 }
 
+export function hasModuleSubtype(objectTypeCode: string, subtypeCode: string): boolean {
+	return getModuleUiConfig(objectTypeCode)?.subtypes.some((subtype) => subtype.code === subtypeCode) ?? false;
+}
+
 export function getEntityKindLabel(entityKind: string): string {
 	switch (entityKind) {
 		case "person":

--- a/packages/plugins/sikesra/src/services/draft.ts
+++ b/packages/plugins/sikesra/src/services/draft.ts
@@ -8,6 +8,7 @@ import { guardRoute } from "../security/route-guard.js";
 export interface DraftCreateInput {
 	objectTypeCode: string;
 	objectSubtypeCode: string;
+	selectedSubtypeModuleCode?: string;
 	entityKind: string;
 	displayName: string;
 	officialVillageCode: string;

--- a/packages/plugins/sikesra/src/services/verification.ts
+++ b/packages/plugins/sikesra/src/services/verification.ts
@@ -1,8 +1,8 @@
 import { sql } from "kysely";
-
 import { AUDIT_ACTIONS, type AuditAction } from "../security/audit.js";
 import type { SikesraRequestContext } from "../security/request-context.js";
 import { guardRoute } from "../security/route-guard.js";
+import { validateEntity } from "./draft.js";
 
 export interface VerificationSubmitInput {
 	entityId: string;
@@ -85,6 +85,39 @@ export async function submitForVerification(
 	const entity = await getEntityForVerification(db, ctx, input.entityId);
 	if (!entity)
 		return throwRouteError("NOT_FOUND", "Entity not found or not eligible for verification", 404);
+
+	const validation = await validateEntity(db, ctx, input.entityId);
+	const invalidSections = validation.sections.filter((section) => !section.isValid);
+	if (invalidSections.length > 0) {
+		await writeVerificationBlockedAudit(
+			db,
+			ctx,
+			input.entityId,
+			"Submit diblokir karena masih ada field wajib yang belum lengkap",
+			{ invalidSections: invalidSections.map((section) => section.sectionKey) },
+		);
+		return throwRouteError(
+			"VALIDATION_ERROR",
+			"Submit diblokir karena masih ada field wajib yang belum lengkap",
+			400,
+		);
+	}
+
+	const blockingDuplicates = await countHighRiskDuplicateCandidates(db, ctx, input.entityId);
+	if (blockingDuplicates > 0) {
+		await writeVerificationBlockedAudit(
+			db,
+			ctx,
+			input.entityId,
+			"Submit diblokir karena ada kandidat duplikat berisiko tinggi yang harus ditinjau",
+			{ blockingDuplicates },
+		);
+		return throwRouteError(
+			"VALIDATION_ERROR",
+			"Submit diblokir karena ada kandidat duplikat berisiko tinggi yang harus ditinjau",
+			400,
+		);
+	}
 
 	const previousStatus = entity.status_verification;
 	const nextStatus = "pending_verification";
@@ -395,6 +428,32 @@ async function getEntityForVerification(db: unknown, ctx: SikesraRequestContext,
 	return result.rows[0];
 }
 
+async function countHighRiskDuplicateCandidates(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	entityId: string,
+): Promise<number> {
+	const result = await sql<{ total: number }>`
+		SELECT COUNT(*) AS total
+		FROM awcms_sikesra_duplicate_candidates candidate
+		JOIN awcms_sikesra_entities other_entity
+			ON other_entity.tenant_id = candidate.tenant_id
+			AND other_entity.site_id = candidate.site_id
+			AND (
+				(candidate.entity_id_a = ${entityId} AND other_entity.id = candidate.entity_id_b)
+				OR (candidate.entity_id_b = ${entityId} AND other_entity.id = candidate.entity_id_a)
+			)
+		WHERE candidate.tenant_id = ${ctx.tenantId}
+			AND candidate.site_id = ${ctx.siteId}
+			AND candidate.deleted_at IS NULL
+			AND other_entity.deleted_at IS NULL
+			AND candidate.risk_level IN ('high', 'blocking')
+			AND (candidate.entity_id_a = ${entityId} OR candidate.entity_id_b = ${entityId})
+	`.execute(db as never);
+
+	return result.rows[0]?.total ?? 0;
+}
+
 function buildQueueWhereSql(ctx: SikesraRequestContext, filters: VerificationQueueFilters) {
 	const conditions = [
 		sql`entity.tenant_id = ${ctx.tenantId}`,
@@ -469,7 +528,88 @@ async function writeVerificationAudit(
 	}
 }
 
+async function writeVerificationBlockedAudit(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	entityId: string,
+	reason: string,
+	metadata: Record<string, unknown>,
+): Promise<void> {
+	try {
+		await sql`
+			INSERT INTO awcms_sikesra_audit_logs (
+				id, tenant_id, site_id, actor_id, actor_role, action,
+				resource_type, resource_id, request_id, success, reason,
+				before_json, after_json, ip_address, user_agent, created_at
+			) VALUES (
+				${`audit_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`},
+				${ctx.tenantId}, ${ctx.siteId}, ${ctx.userId},
+				${ctx.roles[0] ?? "unknown"}, ${AUDIT_ACTIONS.ACCESS_DENIED},
+				'entity', ${entityId}, ${ctx.requestId}, 0, ${reason},
+				${null}, ${JSON.stringify(metadata)},
+				${ctx.ipAddress ?? null}, ${ctx.userAgent ?? null},
+				datetime('now')
+			)
+		`.execute(db as never);
+	} catch {
+		// Audit write failures should not block the main operation
+	}
+}
+
 async function throwRouteError(code: string, message: string, status: number): Promise<never> {
-	const { PluginRouteError } = await import("emdash");
-	throw new PluginRouteError(code, message, status);
+	const mod = (await import("emdash")) as {
+		PluginRouteError?: {
+			new (code: string, message: string, status?: number, details?: unknown): Error & {
+				code: string;
+				status: number;
+			};
+			badRequest?: (message: string, details?: unknown) => Error & { code: string; status: number };
+			forbidden?: (message?: string) => Error & { code: string; status: number };
+			notFound?: (message?: string) => Error & { code: string; status: number };
+			internal?: (message?: string) => Error & { code: string; status: number };
+		};
+		default?: {
+			PluginRouteError?: {
+				new (code: string, message: string, status?: number, details?: unknown): Error & {
+					code: string;
+					status: number;
+				};
+				badRequest?: (message: string, details?: unknown) => Error & { code: string; status: number };
+				forbidden?: (message?: string) => Error & { code: string; status: number };
+				notFound?: (message?: string) => Error & { code: string; status: number };
+				internal?: (message?: string) => Error & { code: string; status: number };
+			};
+		};
+	};
+	const PluginRouteError = mod.PluginRouteError ?? mod.default?.PluginRouteError;
+
+	if (PluginRouteError?.badRequest && status === 400) {
+		const error = PluginRouteError.badRequest(message);
+		error.code = code;
+		throw error;
+	}
+	if (PluginRouteError?.forbidden && status === 403) {
+		const error = PluginRouteError.forbidden(message);
+		error.code = code;
+		throw error;
+	}
+	if (PluginRouteError?.notFound && status === 404) {
+		const error = PluginRouteError.notFound(message);
+		error.code = code;
+		throw error;
+	}
+	if (PluginRouteError?.internal && status >= 500) {
+		const error = PluginRouteError.internal(message);
+		error.code = code;
+		throw error;
+	}
+	if (PluginRouteError) {
+		throw new PluginRouteError(code, message, status);
+	}
+
+	const fallback = new Error(message) as Error & { code: string; status: number };
+	fallback.name = "PluginRouteError";
+	fallback.code = code;
+	fallback.status = status;
+	throw fallback;
 }

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -196,9 +196,8 @@ describe("SIKESRA admin entity workflow", () => {
 				entityId: "entity-doc",
 				fileName: "ktp.pdf",
 				documentType: "ktp",
-				mimeType: "application/pdf",
-				sizeBytes: "1024",
 				classification: "restricted",
+				contentBase64: Buffer.from("pdf-data", "utf8").toString("base64"),
 			},
 		});
 		const stored = await sql<{ total: number }>`
@@ -210,11 +209,118 @@ describe("SIKESRA admin entity workflow", () => {
 		expect(documentStep.blocks).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ type: "header", text: "Dokumen Pendukung" }),
+				expect.objectContaining({ type: "banner", title: "Workflow Upload Dokumen" }),
 				expect.objectContaining({ type: "form" }),
 			]),
 		);
+		const formBlock = documentStep.blocks.find((block) => block.type === "form");
+		const formFields = Array.isArray(formBlock?.fields) ? formBlock.fields : [];
+		expect(formFields.find((field) => field.action_id === "mimeType")).toBeUndefined();
+		expect(formFields.find((field) => field.action_id === "sizeBytes")).toBeUndefined();
+		expect(formFields.find((field) => field.action_id === "contentBase64")).toEqual(
+			expect.objectContaining({ label: "Konten File Base64 (opsional untuk shell ini)" }),
+		);
 		expect(registered.toast).toEqual({ message: "Dokumen berhasil dicatat", type: "success" });
 		expect(stored.rows[0]?.total).toBe(1);
+	});
+
+	it("prepares a guided upload handoff when file content is not provided", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-doc-prep', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Upload', '6201011001', 'local-1', 'Jl. Upload', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+		`);
+
+		const prepared = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: {
+				action_id: "entities:document_register",
+				entityId: "entity-doc-prep",
+				fileName: "kk.pdf",
+				documentType: "kk",
+				classification: "restricted",
+			},
+		});
+		const pendingFiles = await sql<{ total: number; id: string | null }>`
+			SELECT COUNT(*) as total, MAX(id) as id
+			FROM awcms_sikesra_file_objects
+			WHERE tenant_id = 'tenant-1' AND site_id = 'site-1'
+		`.execute(db);
+
+		expect(prepared.toast).toEqual({ message: "Handoff upload siap digunakan", type: "info" });
+		expect(prepared.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "banner", title: "Handoff Upload API" }),
+				expect.objectContaining({ type: "fields" }),
+			]),
+		);
+		const handoffFields = prepared.blocks.find((block) => block.type === "fields");
+		expect(handoffFields).toEqual(
+			expect.objectContaining({
+				fields: expect.arrayContaining([
+					expect.objectContaining({ label: "Entity ID", value: "entity-doc-prep" }),
+					expect.objectContaining({ label: "File Object ID", value: expect.stringContaining("doc_") }),
+					expect.objectContaining({ label: "API Complete Upload", value: expect.stringContaining("/v1/documents/complete") }),
+				]),
+			}),
+		);
+		expect(pendingFiles.rows[0]?.total).toBe(1);
+		expect(pendingFiles.rows[0]?.id).toContain("doc_");
+	});
+
+	it("keeps invalid file-name errors inside the document step", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-doc-invalid', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Invalid', '6201011001', 'local-1', 'Jl. Invalid', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+		`);
+
+		const invalid = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: {
+				action_id: "entities:document_register",
+				entityId: "entity-doc-invalid",
+				fileName: "scan.heic",
+				documentType: "kk",
+				classification: "restricted",
+			},
+		});
+
+		expect(invalid.toast).toEqual({
+			message: "Tipe file belum didukung dari nama file yang diberikan.",
+			type: "error",
+		});
+		expect(invalid.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "banner", title: "Dokumen Tidak Valid" }),
+				expect.objectContaining({ type: "header", text: "Dokumen Pendukung" }),
+			]),
+		);
+	});
+
+	it("shows a friendly required-input error for incomplete document handoff forms", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-doc-missing', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Missing', '6201011001', 'local-1', 'Jl. Missing', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+		`);
+
+		const missing = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: {
+				action_id: "entities:document_register",
+				entityId: "entity-doc-missing",
+				fileName: "ktp.pdf",
+				classification: "restricted",
+			},
+		});
+
+		expect(missing.toast).toEqual({
+			message: "Nama file, jenis dokumen, dan entity ID wajib diisi.",
+			type: "error",
+		});
+		expect(missing.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "banner", title: "Dokumen Tidak Valid" }),
+			]),
+		);
 	});
 
 	it("shows operator-friendly module choices in create flow and registry filters", async () => {

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -66,7 +66,7 @@ describe("SIKESRA admin entity workflow", () => {
 			values: {
 				action_id: "entities:create_draft",
 				objectTypeCode: "01",
-				objectSubtypeCode: "01",
+				objectSubtypeCode: "01:01",
 				entityKind: "building",
 				displayName: "Masjid Admin",
 				officialVillageCode: "6201011001",
@@ -83,13 +83,37 @@ describe("SIKESRA admin entity workflow", () => {
 		);
 	});
 
+	it("rejects a mismatched module and subtype pair in the create flow", async () => {
+		const response = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: {
+				action_id: "entities:create_draft",
+				objectTypeCode: "01",
+				objectSubtypeCode: "06:01",
+				entityKind: "building",
+				displayName: "Masjid Salah Subjenis",
+				officialVillageCode: "6201011001",
+			},
+		});
+
+		expect(response.toast).toEqual({
+			message: "Subjenis data tidak cocok dengan modul yang dipilih",
+			type: "error",
+		});
+		expect(response.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "banner", title: "Subjenis Tidak Sesuai" }),
+			]),
+		);
+	});
+
 	it("archives and restores an entity through admin actions", async () => {
 		await buildAdminPage(db, makeContext(), "/entities", {
 			type: "form_submit",
 			values: {
 				action_id: "entities:create_draft",
 				objectTypeCode: "01",
-				objectSubtypeCode: "01",
+				objectSubtypeCode: "01:01",
 				entityKind: "building",
 				displayName: "Masjid Arsip UI",
 				officialVillageCode: "6201011001",

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -326,7 +326,33 @@ describe("SIKESRA admin entity workflow", () => {
 		expect(review.blocks).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ type: "header", text: "Review dan Submit" }),
+				expect.objectContaining({ type: "banner" }),
 				expect.objectContaining({ type: "stats" }),
+			]),
+		);
+	});
+
+	it("blocks submit form when high-risk duplicate readiness fails even after validation passes", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-submit-blocked', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Blok Submit', '6201011001', 'local-1', 'Jl. Blok', 'draft', 'draft', NULL, 'internal', 100, 'candidate', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+			INSERT INTO awcms_sikesra_rumah_ibadah_details VALUES
+			('detail-submit-blocked', 'tenant-1', 'site-1', 'entity-submit-blocked', 'Masjid', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '2026-01-01', '2026-01-02', NULL, 'admin-1', 'admin-1');
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-other', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Lain', '6201011001', 'local-1', 'Jl. Lain', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+			INSERT INTO awcms_sikesra_duplicate_candidates VALUES
+			('dup-submit-1', 'tenant-1', 'site-1', 'entity-submit-blocked', 'entity-other', '["same_name"]', 0.95, 'high', 'system', NULL, '2026-01-03', '2026-01-03', NULL, 'admin-1', 'admin-1');
+		`);
+
+		const submitView = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "block_action",
+			values: { action_id: "entities:open_submit", entityId: "entity-submit-blocked" },
+		});
+
+		expect(submitView.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "header", text: "Ajukan Verifikasi" }),
+				expect.objectContaining({ type: "banner", title: "Belum Bisa Diajukan" }),
 			]),
 		);
 	});

--- a/packages/plugins/sikesra/tests/document.test.ts
+++ b/packages/plugins/sikesra/tests/document.test.ts
@@ -6,7 +6,9 @@ import { describe, expect, it } from "vitest";
 
 import {
 	completeUpload,
+	estimateBase64SizeBytes,
 	generateUploadUrl,
+	guessMimeTypeFromFilename,
 	getDocumentDownload,
 	getEntityDocuments,
 	replaceDocument,
@@ -129,6 +131,13 @@ function makeContext() {
 }
 
 describe("SIKESRA document workflow", () => {
+	it("derives mime type and base64 size from uploaded file metadata", () => {
+		expect(guessMimeTypeFromFilename("ktp.pdf")).toBe("application/pdf");
+		expect(guessMimeTypeFromFilename("foto.JPG")).toBe("image/jpeg");
+		expect(guessMimeTypeFromFilename("unknown.bin")).toBeNull();
+		expect(estimateBase64SizeBytes(Buffer.from("pdf-data", "utf8").toString("base64"))).toBe(8);
+	});
+
 	it("rejects invalid mime types", async () => {
 		await expect(
 			generateUploadUrl(
@@ -156,6 +165,7 @@ describe("SIKESRA document workflow", () => {
 			ctx,
 			runtime,
 		);
+		expect(upload.uploadUrl).toContain("/_emdash/api/plugins/sikesra/v1/documents/complete");
 		const completed = await completeUpload(
 			{
 				fileObjectId: upload.fileObjectId,

--- a/packages/plugins/sikesra/tests/module-ui-config.test.ts
+++ b/packages/plugins/sikesra/tests/module-ui-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { SIKESRA_DETAIL_MODULES } from "../src/detail-modules.js";
 import { getModuleUiConfig, listModuleUiConfigs } from "../src/module-ui-config.js";
 
 describe("SIKESRA module UI config", () => {
@@ -24,8 +25,33 @@ describe("SIKESRA module UI config", () => {
 		);
 	});
 
+	it("matches detail-modules.ts field coverage and required flags for all 8 modules", () => {
+		for (const [objectTypeCode, detailModule] of Object.entries(SIKESRA_DETAIL_MODULES)) {
+			const moduleConfig = getModuleUiConfig(objectTypeCode);
+
+			expect(moduleConfig, `Missing module UI config for ${objectTypeCode}`).toBeDefined();
+			expect(moduleConfig?.detailFields.map((field) => field.key)).toEqual(detailModule.fields);
+
+			expect(
+				moduleConfig?.detailFields.filter((field) => field.required).map((field) => field.key),
+				`Required fields in ${objectTypeCode} must align exactly with detail-modules.ts`,
+			).toEqual(detailModule.requiredFields);
+
+			for (const fieldConfig of moduleConfig?.detailFields ?? []) {
+				expect(fieldConfig.label, `Field ${fieldConfig.key} in ${objectTypeCode} needs a readable label`).not.toBe(fieldConfig.key);
+			}
+		}
+	});
+
 	it("marks person-profile modules clearly for interim UX", () => {
-		for (const code of ["05", "06", "07", "08"]) {
+		const expectedHelperText = {
+			"05": "Gunakan ID profil orang yang tersedia. Pencarian/linking profil akan ditingkatkan pada tindak lanjut terpisah.",
+			"06": "Gunakan ID profil orang yang tersedia. Detail identitas sensitif tetap dimask server-side.",
+			"07": "Gunakan ID profil orang yang tersedia. Detail sensitif tidak akan ditampilkan penuh pada review umum.",
+			"08": "Gunakan ID profil orang yang tersedia. Workflow pencarian/linking profil masih akan ditingkatkan.",
+		} as const;
+
+		for (const code of ["05", "06", "07", "08"] as const) {
 			const moduleConfig = getModuleUiConfig(code);
 			const personProfileField = moduleConfig?.detailFields.find((field) => field.key === "person_profile_id");
 
@@ -33,9 +59,54 @@ describe("SIKESRA module UI config", () => {
 				expect.objectContaining({
 					label: "Person Profile",
 					required: true,
-					helperText: expect.stringContaining("profil"),
+					helperText: expectedHelperText[code],
 				}),
 			);
+		}
+	});
+
+	it("provides options for every select field", () => {
+		const expectedSubtypeCounts = {
+			"01": 8,
+			"02": 7,
+			"03": 3,
+			"04": 8,
+			"05": 3,
+			"06": 3,
+			"07": 4,
+			"08": 3,
+		} as const;
+		const expectedSelectValues: Record<string, string[]> = {
+			"01.jenis_rumah_ibadah": ["Masjid", "Musholla", "Surau", "Gereja", "Pura", "Wihara", "Klenteng", "Lainnya"],
+			"01.status_pembangunan": ["beroperasi", "dalam_pembangunan", "renovasi"],
+			"02.agama": ["Islam", "Kristen", "Katolik", "Hindu", "Buddha", "Konghucu", "Lainnya"],
+			"03.jenis_pendidikan": ["TPA/TPQ", "Pondok Pesantren", "Lainnya"],
+			"03.status_akreditasi": ["terakreditasi", "proses", "belum"],
+			"04.jenis_lks": ["BAZNAS", "PWRI", "Panti Asuhan", "Panti Yatim", "Panti Jompo", "Rukun Kematian", "Majelis Taklim", "LKS Lainnya"],
+			"05.agama": ["Islam", "Kristen", "Katolik", "Hindu", "Buddha", "Konghucu", "Lainnya"],
+			"05.status_guru": ["aktif", "tidak_aktif", "pensiun", "almarhum"],
+			"06.kategori_anak": ["yatim", "piatu", "yatim_piatu"],
+			"07.jenis_disabilitas": ["Fisik", "Intelektual", "Mental", "Sensorik"],
+			"07.tingkat_keparahan": ["ringan", "sedang", "berat"],
+			"07.alat_bantu_dibutuhkan": ["1", "0"],
+			"08.status_keterlantaran": ["terlantar", "rawan_terlantar", "mandiri_risiko"],
+			"08.status_tinggal": ["sendiri", "pasangan", "keluarga", "panti"],
+		};
+
+		for (const moduleConfig of listModuleUiConfigs()) {
+			expect(moduleConfig.subtypes.length).toBe(expectedSubtypeCounts[moduleConfig.objectTypeCode as keyof typeof expectedSubtypeCounts]);
+
+			for (const fieldConfig of moduleConfig.detailFields) {
+				if (fieldConfig.input !== "select") continue;
+				const expectedValues = expectedSelectValues[`${moduleConfig.objectTypeCode}.${fieldConfig.key}`];
+
+				expect(
+					fieldConfig.options?.length,
+					`Select field ${moduleConfig.objectTypeCode}.${fieldConfig.key} must define options`,
+				).toBeGreaterThan(0);
+				expect(fieldConfig.options?.every((option) => option.label.trim().length > 0 && option.value.trim().length > 0)).toBe(true);
+				expect(fieldConfig.options?.map((option) => option.value)).toEqual(expectedValues);
+			}
 		}
 	});
 });

--- a/packages/plugins/sikesra/tests/verification.test.ts
+++ b/packages/plugins/sikesra/tests/verification.test.ts
@@ -1,0 +1,152 @@
+import Database from "better-sqlite3";
+import { Kysely, SqliteDialect, sql } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { buildTrustedRequestContext } from "../src/security/request-context.js";
+import { SIKESRA_PERMISSION_LIST } from "../src/security/permissions.js";
+import { createDraft } from "../src/services/draft.js";
+import { submitForVerification } from "../src/services/verification.js";
+
+let sqlite: Database.Database;
+let db: Kysely<unknown>;
+
+function makeContext() {
+	return buildTrustedRequestContext({
+		requestId: "req-verification",
+		tenantId: "tenant-1",
+		siteId: "site-1",
+		userId: "admin-1",
+		roles: ["admin"],
+		permissions: [...SIKESRA_PERMISSION_LIST],
+		regionScope: {},
+	});
+}
+
+beforeEach(() => {
+	sqlite = new Database(":memory:");
+	db = new Kysely({ dialect: new SqliteDialect({ database: sqlite }) });
+
+	sqlite.exec(`
+		CREATE TABLE awcms_sikesra_official_regions (code TEXT, tenant_id TEXT, site_id TEXT, name TEXT, level TEXT, parent_code TEXT, deleted_at TEXT);
+		CREATE TABLE awcms_sikesra_object_types (code TEXT, tenant_id TEXT, site_id TEXT, name TEXT, deleted_at TEXT);
+		CREATE TABLE awcms_sikesra_object_subtypes (code TEXT, type_code TEXT, tenant_id TEXT, site_id TEXT, name TEXT, deleted_at TEXT);
+		CREATE TABLE awcms_sikesra_entities (
+			id TEXT, tenant_id TEXT, site_id TEXT, sikesra_id_20 TEXT, object_type_code TEXT, object_subtype_code TEXT,
+			entity_kind TEXT, display_name TEXT, official_village_code TEXT, local_region_id TEXT, address_text TEXT,
+			status_data TEXT, status_verification TEXT, verification_level TEXT, sensitivity_level TEXT,
+			completeness_percent INTEGER, duplicate_status TEXT, source_input TEXT, created_at TEXT, updated_at TEXT,
+			verified_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT
+		);
+		CREATE TABLE awcms_sikesra_person_profiles (id TEXT);
+		CREATE TABLE awcms_sikesra_code_sequences (id TEXT, tenant_id TEXT, site_id TEXT, official_village_code TEXT, object_type_code TEXT, object_subtype_code TEXT, last_sequence INTEGER, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+		CREATE TABLE awcms_sikesra_rumah_ibadah_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, jenis_rumah_ibadah TEXT, status_pembangunan TEXT, luas_bangunan REAL, luas_tanah REAL, kapasitas_jamaah INTEGER, tahun_didirikan INTEGER, imam_nama TEXT, pengurus_nama TEXT, kegiatan_rutin TEXT, sumber_dana TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+		CREATE TABLE awcms_sikesra_duplicate_candidates (id TEXT, tenant_id TEXT, site_id TEXT, entity_id_a TEXT, entity_id_b TEXT, match_signals_json TEXT, match_score REAL, risk_level TEXT, detection_source TEXT, import_batch_id TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+		CREATE TABLE awcms_sikesra_verification_events (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, actor_id TEXT, actor_role TEXT, verification_level TEXT, action TEXT, previous_status TEXT, next_status TEXT, note TEXT, request_id TEXT, ip_address TEXT, created_at TEXT);
+		CREATE TABLE awcms_sikesra_audit_logs (id TEXT, tenant_id TEXT, site_id TEXT, actor_id TEXT, actor_role TEXT, action TEXT, resource_type TEXT, resource_id TEXT, request_id TEXT, success INTEGER, reason TEXT, before_json TEXT, after_json TEXT, ip_address TEXT, user_agent TEXT, created_at TEXT);
+	`);
+
+	sqlite.exec(`
+		INSERT INTO awcms_sikesra_official_regions VALUES ('6201011001', 'tenant-1', 'site-1', 'Desa Aman', 'village', '620101', NULL);
+		INSERT INTO awcms_sikesra_object_types VALUES ('01', 'tenant-1', 'site-1', 'Rumah Ibadah', NULL);
+		INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '01', 'tenant-1', 'site-1', 'Masjid', NULL);
+	`);
+});
+
+afterEach(async () => {
+	await db.destroy();
+	sqlite.close();
+});
+
+describe("SIKESRA verification submit gating", () => {
+	it("allows valid submit when validation passes and no high-risk duplicates exist", async () => {
+		const ctx = makeContext();
+		const created = await createDraft(db, ctx, {
+			objectTypeCode: "01",
+			objectSubtypeCode: "01",
+			entityKind: "building",
+			displayName: "Masjid Valid",
+			officialVillageCode: "6201011001",
+			initialData: { jenis_rumah_ibadah: "Masjid" },
+		});
+
+		const submitted = await submitForVerification(db, ctx, { entityId: created.entityId });
+		const entityRow = await sql<{ status_verification: string }>`
+			SELECT status_verification FROM awcms_sikesra_entities WHERE id = ${created.entityId} LIMIT 1
+		`.execute(db);
+
+		expect(submitted.nextStatus).toBe("pending_verification");
+		expect(entityRow.rows[0]?.status_verification).toBe("pending_verification");
+	});
+
+	it("blocks submit when required validation is still failing", async () => {
+		const ctx = makeContext();
+		const created = await createDraft(db, ctx, {
+			objectTypeCode: "01",
+			objectSubtypeCode: "01",
+			entityKind: "building",
+			displayName: "Masjid Belum Lengkap",
+			officialVillageCode: "6201011001",
+		});
+
+		await expect(submitForVerification(db, ctx, { entityId: created.entityId })).rejects.toThrow(
+			"Submit diblokir karena masih ada field wajib yang belum lengkap",
+		);
+
+		const auditRows = await sql<{ action: string; success: number; reason: string | null }>`
+			SELECT action, success, reason
+			FROM awcms_sikesra_audit_logs
+			WHERE resource_id = ${created.entityId}
+				AND action = 'security.access_denied'
+			ORDER BY created_at DESC
+			LIMIT 1
+		`.execute(db);
+
+		expect(auditRows.rows[0]).toEqual(
+			expect.objectContaining({
+				action: "security.access_denied",
+				success: 0,
+				reason: "Submit diblokir karena masih ada field wajib yang belum lengkap",
+			}),
+		);
+	});
+
+	it("blocks submit when high-risk duplicate candidates remain", async () => {
+		const ctx = makeContext();
+		const created = await createDraft(db, ctx, {
+			objectTypeCode: "01",
+			objectSubtypeCode: "01",
+			entityKind: "building",
+			displayName: "Masjid Duplikat",
+			officialVillageCode: "6201011001",
+			initialData: { jenis_rumah_ibadah: "Masjid" },
+		});
+
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-other', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Pembanding', '6201011001', NULL, 'Jl. Pembanding', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+			INSERT INTO awcms_sikesra_duplicate_candidates VALUES
+			('dup-high-1', 'tenant-1', 'site-1', '${created.entityId}', 'entity-other', '["same_name"]', 0.98, 'high', 'system', NULL, '2026-01-03', '2026-01-03', NULL, 'admin-1', 'admin-1');
+		`);
+
+		await expect(submitForVerification(db, ctx, { entityId: created.entityId })).rejects.toThrow(
+			"Submit diblokir karena ada kandidat duplikat berisiko tinggi yang harus ditinjau",
+		);
+
+		const auditRows = await sql<{ action: string; success: number; reason: string | null }>`
+			SELECT action, success, reason
+			FROM awcms_sikesra_audit_logs
+			WHERE resource_id = ${created.entityId}
+				AND action = 'security.access_denied'
+			ORDER BY created_at DESC
+			LIMIT 1
+		`.execute(db);
+
+		expect(auditRows.rows[0]).toEqual(
+			expect.objectContaining({
+				action: "security.access_denied",
+				success: 0,
+				reason: "Submit diblokir karena ada kandidat duplikat berisiko tinggi yang harus ditinjau",
+			}),
+		);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Restores the resolved `#285` delta onto `main` after the previous stacked PR auto-closed when its base branch merged. This improves the SIKESRA document step with guided metadata derivation and a resumable API handoff.

Closes #285

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- `packages/plugins/sikesra`: `pnpm typecheck` passes.
- `packages/plugins/sikesra`: `pnpm test -- --runInBand` passes.
- Root repo blockers remain unchanged outside SIKESRA.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4
