### PR TITLE
feat: improve document step upload handoff

### DIFF
--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -9,9 +9,12 @@ import {
 	getModuleUiFieldConfig,
 	listModuleUiConfigs,
 } from "./module-ui-config.js";
+import { SIKESRA_API_BASE } from "./shared.js";
 import {
 	completeUpload,
+	estimateBase64SizeBytes,
 	generateUploadUrl,
+	guessMimeTypeFromFilename,
 	getEntityDocuments,
 	validateUploadInput,
 	type CompleteUploadInput,
@@ -69,6 +72,10 @@ interface EntitySubmitReadiness {
 	recommendedAction: string;
 	reasonMessage?: string;
 }
+
+interface AdminDocumentRegisterInput
+	extends GenerateUploadUrlInput,
+		Pick<CompleteUploadInput, "entityId" | "documentType" | "checksumSha256" | "contentBase64"> {}
 
 // ── Admin Page Router ────────────────────────────────────────────────────────
 
@@ -1431,10 +1438,42 @@ async function handleEntityAction(
 		if (entityId) return buildEntityReviewSummary(db, ctx, entityId);
 	}
 	if (actionId === "entities:document_register") {
-		const input = normalizeDocumentRegisterForm(action.values);
-		await registerEntityDocument(db, ctx, input);
-		const step = await buildEntityDocumentStep(db, ctx, input.entityId);
-		return { ...step, toast: { message: "Dokumen berhasil dicatat", type: "success" } };
+		try {
+			const input = normalizeDocumentRegisterForm(action.values);
+			const registered = await registerEntityDocument(db, ctx, input);
+			if (registered.mode === "prepared") {
+				return buildPreparedDocumentUploadStep(db, ctx, input.entityId, {
+					entityId: input.entityId,
+					fileName: input.fileName,
+					documentType: input.documentType,
+					classification: input.classification,
+					mimeType: input.mimeType,
+					fileObjectId: registered.upload.fileObjectId,
+				});
+			}
+			const step = await buildEntityDocumentStep(db, ctx, input.entityId);
+			return { ...step, toast: { message: "Dokumen berhasil dicatat", type: "success" } };
+		} catch (error) {
+			const entityId = typeof action.values?.entityId === "string" ? action.values.entityId : "";
+			const step = entityId ? await buildEntityDocumentStep(db, ctx, entityId) : { blocks: [] };
+			const rawMessage = error instanceof Error ? error.message : "Dokumen tidak valid";
+			const message = rawMessage === "DOCUMENT_REGISTER_INPUT_REQUIRED"
+				? "Nama file, jenis dokumen, dan entity ID wajib diisi."
+				: rawMessage.replace(/^DOCUMENT_REGISTER_INVALID:\s*/, "");
+			return {
+				...step,
+				blocks: [
+					{
+						type: "banner",
+						variant: "error",
+						title: "Dokumen Tidak Valid",
+						description: message,
+					},
+					...step.blocks,
+				],
+				toast: { message: message || "Dokumen tidak valid", type: "error" },
+			};
+		}
 	}
 	if (actionId === "entities:update_section") {
 		const input = normalizeDraftUpdateForm(action.values);
@@ -1907,13 +1946,28 @@ async function buildEntityDocumentStep(
 			...buildEntityWizardSteps(entityId, 4),
 			{ type: "divider" },
 			{
+				type: "banner",
+				variant: "info",
+				title: "Workflow Upload Dokumen",
+				description: "MIME type diturunkan dari nama file dan ukuran dihitung dari payload file yang diberikan di shell ini. Jika shell belum bisa unggah file langsung, gunakan handoff API upload yang aman tanpa mengisi metadata teknis secara manual.",
+			},
+			{
 				type: "form",
 				fields: [
 					{ type: "text_input", action_id: "entityId", label: "Entity ID", value: entityId },
 					{ type: "text_input", action_id: "fileName", label: "Nama File", placeholder: "ktp.pdf" },
-					{ type: "text_input", action_id: "documentType", label: "Jenis Dokumen", placeholder: "ktp / kk / surat_keterangan" },
-					{ type: "text_input", action_id: "mimeType", label: "MIME Type", value: "application/pdf" },
-					{ type: "text_input", action_id: "sizeBytes", label: "Ukuran (bytes)", value: "1024" },
+					{
+						type: "select",
+						action_id: "documentType",
+						label: "Jenis Dokumen",
+						options: [
+							{ label: "KTP", value: "ktp" },
+							{ label: "KK", value: "kk" },
+							{ label: "Surat Keterangan", value: "surat_keterangan" },
+							{ label: "Foto Lokasi", value: "foto_lokasi" },
+							{ label: "Lainnya", value: "lainnya" },
+						],
+					},
 					{
 						type: "select",
 						action_id: "classification",
@@ -1924,9 +1978,16 @@ async function buildEntityDocumentStep(
 							{ label: "Highly Restricted", value: "highly_restricted" },
 						],
 					},
+					{
+						type: "text_input",
+						action_id: "contentBase64",
+						label: "Konten File Base64 (opsional untuk shell ini)",
+						multiline: true,
+						placeholder: "Tempel base64 file untuk simulasi/testing, atau kosongkan untuk menyiapkan upload URL.",
+					},
 					{ type: "text_input", action_id: "checksumSha256", label: "Checksum SHA256", placeholder: "opsional" },
 				],
-				submit: { label: "Catat Dokumen", action_id: "entities:document_register" },
+				submit: { label: "Siapkan / Catat Dokumen", action_id: "entities:document_register" },
 			},
 			{ type: "divider" },
 			...(documents.length === 0
@@ -2329,11 +2390,13 @@ function normalizeEntityLifecycleForm(values: Record<string, unknown> | undefine
 }
 
 function normalizeDocumentRegisterForm(values: Record<string, unknown> | undefined):
-	GenerateUploadUrlInput &
-	Pick<CompleteUploadInput, "entityId" | "documentType" | "checksumSha256"> {
+	AdminDocumentRegisterInput {
 	const fileName = typeof values?.fileName === "string" ? values.fileName : "";
-	const mimeType = typeof values?.mimeType === "string" ? values.mimeType : "application/pdf";
-	const sizeBytesRaw = typeof values?.sizeBytes === "string" ? Number(values.sizeBytes) : values?.sizeBytes;
+	const mimeType = guessMimeTypeFromFilename(fileName) ?? "";
+	const contentBase64 =
+		typeof values?.contentBase64 === "string" && values.contentBase64.trim()
+			? values.contentBase64.trim()
+			: undefined;
 	const classification =
 		typeof values?.classification === "string"
 			? (values.classification as DocumentClassification)
@@ -2343,16 +2406,18 @@ function normalizeDocumentRegisterForm(values: Record<string, unknown> | undefin
 	const input = {
 		fileName,
 		mimeType,
-		sizeBytes: typeof sizeBytesRaw === "number" && Number.isFinite(sizeBytesRaw) ? sizeBytesRaw : 0,
+		sizeBytes: contentBase64 ? estimateBase64SizeBytes(contentBase64) : 0,
 		classification,
 		entityId,
 		documentType,
+		contentBase64,
 		checksumSha256:
 			typeof values?.checksumSha256 === "string" && values.checksumSha256
 				? values.checksumSha256
 				: undefined,
 	};
 	if (!entityId || !documentType) throw new Error("DOCUMENT_REGISTER_INPUT_REQUIRED");
+	if (!mimeType) throw new Error("DOCUMENT_REGISTER_INVALID: Tipe file belum didukung dari nama file yang diberikan.");
 	const errors = validateUploadInput(input);
 	if (errors.length > 0) throw new Error(`DOCUMENT_REGISTER_INVALID: ${errors.join("; ")}`);
 	return input;
@@ -2361,9 +2426,16 @@ function normalizeDocumentRegisterForm(values: Record<string, unknown> | undefin
 async function registerEntityDocument(
 	db: unknown,
 	ctx: SikesraRequestContext,
-	input: GenerateUploadUrlInput & Pick<CompleteUploadInput, "entityId" | "documentType" | "checksumSha256">,
-) {
+	input: AdminDocumentRegisterInput,
+): Promise<{ mode: "prepared" | "completed"; upload: UploadUrlResponse }> {
 	const runtime = buildAdminDocumentRuntime(db);
+	if (!input.contentBase64) {
+		const upload = await generateUploadUrl(input, ctx, runtime);
+		return {
+			mode: "prepared",
+			upload,
+		};
+	}
 	const upload = await generateUploadUrl(input, ctx, runtime);
 	await completeUpload(
 		{
@@ -2371,6 +2443,7 @@ async function registerEntityDocument(
 			entityId: input.entityId,
 			documentType: input.documentType,
 			classification: input.classification,
+			contentBase64: input.contentBase64,
 			checksumSha256: input.checksumSha256,
 			originalFilename: input.fileName,
 			mimeType: input.mimeType,
@@ -2379,7 +2452,47 @@ async function registerEntityDocument(
 		ctx,
 		runtime,
 	);
-	return upload;
+	return { mode: "completed", upload };
+}
+
+async function buildPreparedDocumentUploadStep(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	entityId: string,
+	prepared: {
+		entityId: string;
+		fileName: string;
+		documentType: string;
+		classification: string;
+		mimeType: string;
+		fileObjectId: string;
+	},
+): Promise<BlockResponse> {
+	const step = await buildEntityDocumentStep(db, ctx, entityId);
+	return {
+		blocks: [
+			{
+				type: "banner",
+				variant: "info",
+				title: "Handoff Upload API",
+				description: "Shell admin ini belum mengunggah file biner langsung. Gunakan fileObjectId berikut pada klien/API yang mendukung upload, lalu panggil endpoint complete dengan MIME type, sizeBytes, dan payload file sebenarnya untuk menyimpan metadata akhir dan audit.",
+			},
+			{
+				type: "fields",
+				fields: [
+					{ label: "Entity ID", value: prepared.entityId },
+					{ label: "Nama File", value: prepared.fileName },
+					{ label: "Jenis Dokumen", value: prepared.documentType },
+					{ label: "Klasifikasi", value: prepared.classification },
+					{ label: "MIME Type", value: prepared.mimeType },
+					{ label: "File Object ID", value: prepared.fileObjectId },
+					{ label: "API Complete Upload", value: `${SIKESRA_API_BASE}/v1/documents/complete` },
+				],
+			},
+			...step.blocks,
+		],
+				toast: { message: "Handoff upload siap digunakan", type: "info" },
+			};
 }
 
 function buildModuleDetailFields(

--- a/packages/plugins/sikesra/src/document.ts
+++ b/packages/plugins/sikesra/src/document.ts
@@ -122,6 +122,17 @@ export interface DocumentStorageContext {
 	};
 }
 
+const FILENAME_MIME_MAP: Record<string, string> = {
+	".pdf": "application/pdf",
+	".jpg": "image/jpeg",
+	".jpeg": "image/jpeg",
+	".png": "image/png",
+	".doc": "application/msword",
+	".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+	".xls": "application/vnd.ms-excel",
+	".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+};
+
 const ALLOWED_MIME_TYPES = new Set([
 	"application/pdf",
 	"image/jpeg",
@@ -152,6 +163,19 @@ export function validateUploadInput(input: GenerateUploadUrlInput): string[] {
 		errors.push(`Invalid classification: ${input.classification}.`);
 	}
 	return errors;
+}
+
+export function guessMimeTypeFromFilename(fileName: string): string | null {
+	const normalized = fileName.trim().toLowerCase();
+	const extension = normalized.includes(".") ? normalized.slice(normalized.lastIndexOf(".")) : "";
+	return FILENAME_MIME_MAP[extension] ?? null;
+}
+
+export function estimateBase64SizeBytes(contentBase64: string): number {
+	const normalized = contentBase64.replace(/\s+/g, "");
+	if (!normalized) return 0;
+	const padding = normalized.endsWith("==") ? 2 : normalized.endsWith("=") ? 1 : 0;
+	return Math.max(0, Math.floor((normalized.length * 3) / 4) - padding);
 }
 
 export async function generateUploadUrl(
@@ -188,7 +212,7 @@ export async function generateUploadUrl(
 	}
 
 	return {
-		uploadUrl: `/_emdash/api/plugins/sikesra/v1/documents/${fileObjectId}/upload`,
+		uploadUrl: `/_emdash/api/plugins/sikesra/v1/documents/complete`,
 		fileObjectId,
 	};
 }

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -196,9 +196,8 @@ describe("SIKESRA admin entity workflow", () => {
 				entityId: "entity-doc",
 				fileName: "ktp.pdf",
 				documentType: "ktp",
-				mimeType: "application/pdf",
-				sizeBytes: "1024",
 				classification: "restricted",
+				contentBase64: Buffer.from("pdf-data", "utf8").toString("base64"),
 			},
 		});
 		const stored = await sql<{ total: number }>`
@@ -210,11 +209,118 @@ describe("SIKESRA admin entity workflow", () => {
 		expect(documentStep.blocks).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ type: "header", text: "Dokumen Pendukung" }),
+				expect.objectContaining({ type: "banner", title: "Workflow Upload Dokumen" }),
 				expect.objectContaining({ type: "form" }),
 			]),
 		);
+		const formBlock = documentStep.blocks.find((block) => block.type === "form");
+		const formFields = Array.isArray(formBlock?.fields) ? formBlock.fields : [];
+		expect(formFields.find((field) => field.action_id === "mimeType")).toBeUndefined();
+		expect(formFields.find((field) => field.action_id === "sizeBytes")).toBeUndefined();
+		expect(formFields.find((field) => field.action_id === "contentBase64")).toEqual(
+			expect.objectContaining({ label: "Konten File Base64 (opsional untuk shell ini)" }),
+		);
 		expect(registered.toast).toEqual({ message: "Dokumen berhasil dicatat", type: "success" });
 		expect(stored.rows[0]?.total).toBe(1);
+	});
+
+	it("prepares a guided upload handoff when file content is not provided", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-doc-prep', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Upload', '6201011001', 'local-1', 'Jl. Upload', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+		`);
+
+		const prepared = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: {
+				action_id: "entities:document_register",
+				entityId: "entity-doc-prep",
+				fileName: "kk.pdf",
+				documentType: "kk",
+				classification: "restricted",
+			},
+		});
+		const pendingFiles = await sql<{ total: number; id: string | null }>`
+			SELECT COUNT(*) as total, MAX(id) as id
+			FROM awcms_sikesra_file_objects
+			WHERE tenant_id = 'tenant-1' AND site_id = 'site-1'
+		`.execute(db);
+
+		expect(prepared.toast).toEqual({ message: "Handoff upload siap digunakan", type: "info" });
+		expect(prepared.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "banner", title: "Handoff Upload API" }),
+				expect.objectContaining({ type: "fields" }),
+			]),
+		);
+		const handoffFields = prepared.blocks.find((block) => block.type === "fields");
+		expect(handoffFields).toEqual(
+			expect.objectContaining({
+				fields: expect.arrayContaining([
+					expect.objectContaining({ label: "Entity ID", value: "entity-doc-prep" }),
+					expect.objectContaining({ label: "File Object ID", value: expect.stringContaining("doc_") }),
+					expect.objectContaining({ label: "API Complete Upload", value: expect.stringContaining("/v1/documents/complete") }),
+				]),
+			}),
+		);
+		expect(pendingFiles.rows[0]?.total).toBe(1);
+		expect(pendingFiles.rows[0]?.id).toContain("doc_");
+	});
+
+	it("keeps invalid file-name errors inside the document step", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-doc-invalid', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Invalid', '6201011001', 'local-1', 'Jl. Invalid', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+		`);
+
+		const invalid = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: {
+				action_id: "entities:document_register",
+				entityId: "entity-doc-invalid",
+				fileName: "scan.heic",
+				documentType: "kk",
+				classification: "restricted",
+			},
+		});
+
+		expect(invalid.toast).toEqual({
+			message: "Tipe file belum didukung dari nama file yang diberikan.",
+			type: "error",
+		});
+		expect(invalid.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "banner", title: "Dokumen Tidak Valid" }),
+				expect.objectContaining({ type: "header", text: "Dokumen Pendukung" }),
+			]),
+		);
+	});
+
+	it("shows a friendly required-input error for incomplete document handoff forms", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-doc-missing', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Missing', '6201011001', 'local-1', 'Jl. Missing', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+		`);
+
+		const missing = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: {
+				action_id: "entities:document_register",
+				entityId: "entity-doc-missing",
+				fileName: "ktp.pdf",
+				classification: "restricted",
+			},
+		});
+
+		expect(missing.toast).toEqual({
+			message: "Nama file, jenis dokumen, dan entity ID wajib diisi.",
+			type: "error",
+		});
+		expect(missing.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "banner", title: "Dokumen Tidak Valid" }),
+			]),
+		);
 	});
 
 	it("shows operator-friendly module choices in create flow and registry filters", async () => {

--- a/packages/plugins/sikesra/tests/document.test.ts
+++ b/packages/plugins/sikesra/tests/document.test.ts
@@ -6,7 +6,9 @@ import { describe, expect, it } from "vitest";
 
 import {
 	completeUpload,
+	estimateBase64SizeBytes,
 	generateUploadUrl,
+	guessMimeTypeFromFilename,
 	getDocumentDownload,
 	getEntityDocuments,
 	replaceDocument,
@@ -129,6 +131,13 @@ function makeContext() {
 }
 
 describe("SIKESRA document workflow", () => {
+	it("derives mime type and base64 size from uploaded file metadata", () => {
+		expect(guessMimeTypeFromFilename("ktp.pdf")).toBe("application/pdf");
+		expect(guessMimeTypeFromFilename("foto.JPG")).toBe("image/jpeg");
+		expect(guessMimeTypeFromFilename("unknown.bin")).toBeNull();
+		expect(estimateBase64SizeBytes(Buffer.from("pdf-data", "utf8").toString("base64"))).toBe(8);
+	});
+
 	it("rejects invalid mime types", async () => {
 		await expect(
 			generateUploadUrl(
@@ -156,6 +165,7 @@ describe("SIKESRA document workflow", () => {
 			ctx,
 			runtime,
 		);
+		expect(upload.uploadUrl).toContain("/_emdash/api/plugins/sikesra/v1/documents/complete");
 		const completed = await completeUpload(
 			{
 				fileObjectId: upload.fileObjectId,


### PR DESCRIPTION
## What does this PR do?

Recreates the resolved `#285` delta cleanly on top of current `main`. This improves the SIKESRA document step with guided metadata derivation, direct-content completion, and a resumable complete-endpoint handoff for shells that cannot upload binary files directly.

Closes #285

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- `packages/plugins/sikesra`: `pnpm typecheck` passes.
- `packages/plugins/sikesra`: `pnpm test -- --runInBand` passes.
- Root repo blockers remain unchanged outside SIKESRA.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4
