### PR TITLE
docs: add sikesra operator workflow reference

### DIFF
--- a/docs/sikesra/01_product_requirements.md
+++ b/docs/sikesra/01_product_requirements.md
@@ -67,6 +67,10 @@ The product must support data entry from operators, staged Excel imports, multi-
 | 07   | Disabilitas                  | Fisik, Intelektual, Mental, Sensorik.                                                              |
 | 08   | Lansia Terlantar             | Terlantar, Rawan Terlantar, Mandiri dengan Risiko.                                                 |
 
+## Current Operator Workflow Reference
+
+For the implementation-aligned operator flow, module requirements, person-profile limitations, document handoff behavior, and manual checks, see [operator-workflow.md](operator-workflow.md).
+
 ## Functional Requirements
 
 | ID     | Requirement                                                                                                 | Priority |

--- a/docs/sikesra/08_implementation_backlog.md
+++ b/docs/sikesra/08_implementation_backlog.md
@@ -272,6 +272,12 @@ Priority: P0. Depends on SIKESRA-034.
 
 Priority: P0. Depends on SIKESRA-033, SIKESRA-034, SIKESRA-035.
 
+Current implementation note:
+
+- Core block-based wizard flow is implemented in `packages/plugins/sikesra/src/admin-pages.ts`.
+- Operator-facing workflow reference lives in `docs/sikesra/operator-workflow.md`.
+- Remaining gaps should be tracked atomically, especially person-profile search/link UX and further shell upload ergonomics.
+
 ### SIKESRA-037: Implement 20-digit code generation service
 
 Priority: P0. Depends on SIKESRA-010 and SIKESRA-035.
@@ -323,6 +329,12 @@ Priority: P1. Depends on SIKESRA-045 and SIKESRA-046.
 ### SIKESRA-048: Build document upload/list UI
 
 Priority: P0. Depends on SIKESRA-045 and SIKESRA-046.
+
+Current implementation note:
+
+- Document list and guided upload handoff are implemented.
+- The current shell can complete uploads when payload content is provided, and otherwise returns a resumable API handoff.
+- Native file-picker ergonomics remain a shell-level follow-up, not a reason to re-open core metadata work.
 
 ## Phase 9: Import and Deduplication
 

--- a/docs/sikesra/10_validation_checklist.md
+++ b/docs/sikesra/10_validation_checklist.md
@@ -76,10 +76,14 @@ Use this document before implementation starts, before each phase merge, and bef
 ## Entity and Wizard Validation
 
 - [ ] Draft creation works.
+- [ ] All 8 SIKESRA modules appear in the operator create flow.
+- [ ] Subtype selection is constrained or safely rejected when it does not match the selected module.
 - [ ] Autosave saves section patches.
 - [ ] Validation errors are section-aware.
 - [ ] Completeness recalculates after updates.
 - [ ] Required fields block submit and ID generation.
+- [ ] Review screen shows the next recommended action before submit.
+- [ ] Person-based modules show current `Person Profile` guidance without exposing unsafe personal detail.
 - [ ] Official and local regions are visually and technically distinct.
 - [ ] Detail tables are written according to object type.
 - [ ] Access flags drive UI actions.
@@ -107,9 +111,11 @@ Use this document before implementation starts, before each phase merge, and bef
 ## Document Validation
 
 - [ ] Upload validates MIME, extension, size, checksum, classification.
+- [ ] Operator does not manually type MIME type and size in the normal document step.
 - [ ] Dangerous file types are blocked.
 - [ ] Metadata is stored in D1.
 - [ ] Physical file is stored in R2.
+- [ ] If shell upload is unavailable, resumable handoff includes the fields required by the complete endpoint.
 - [ ] Preview/download uses signed/proxy route.
 - [ ] Raw R2 key is hidden.
 - [ ] Highly restricted download requires reason where configured.

--- a/docs/sikesra/11_ai_implementation_handoff.md
+++ b/docs/sikesra/11_ai_implementation_handoff.md
@@ -152,13 +152,13 @@ Use this map to keep prompts small.
 | Database migrations    | `03_data_model.md`, relevant backlog ticket, this handoff.                       |
 | API endpoint           | `04_api_contracts.md`, `06_security_rbac_abac.md`, this handoff.                 |
 | Public page            | `01_product_requirements.md`, `05_ui_ux.md`, `06_security_rbac_abac.md`.         |
-| Admin UI               | `05_ui_ux.md`, `04_api_contracts.md`, this handoff.                              |
+| Admin UI               | `05_ui_ux.md`, `04_api_contracts.md`, `operator-workflow.md`, this handoff.      |
 | Security and ABAC      | `06_security_rbac_abac.md`, `02_architecture.md`, `10_validation_checklist.md`.  |
 | Import workflow        | `07_operations_sop.md`, `03_data_model.md`, `04_api_contracts.md`.               |
 | Documents and R2       | `02_architecture.md`, `03_data_model.md`, `06_security_rbac_abac.md`.            |
 | Verification workflow  | `07_operations_sop.md`, `04_api_contracts.md`, `06_security_rbac_abac.md`.       |
 | Reports and exports    | `04_api_contracts.md`, `06_security_rbac_abac.md`, `10_validation_checklist.md`. |
-| Release validation     | `09_12_week_mvp_plan.md`, `10_validation_checklist.md`.                          |
+| Release validation     | `09_12_week_mvp_plan.md`, `10_validation_checklist.md`, `operator-workflow.md`.  |
 
 ## Phase 0 Prompt Pack
 

--- a/docs/sikesra/README.md
+++ b/docs/sikesra/README.md
@@ -18,7 +18,7 @@ Sistem Informasi Kesejahteraan Rakyat — native AWCMS-Micro / EmDash-compatible
 | 10    | [10_validation_checklist.md](10_validation_checklist.md)           | Final validation checklist for implementation readiness                 |
 | 11    | [11_ai_implementation_handoff.md](11_ai_implementation_handoff.md) | Handoff guide for junior programmers and AI coding agents               |
 
-Additional planning docs: [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md), [IMPLEMENTATION_DECISIONS.md](IMPLEMENTATION_DECISIONS.md).
+Additional planning docs: [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md), [IMPLEMENTATION_DECISIONS.md](IMPLEMENTATION_DECISIONS.md), [operator-workflow.md](operator-workflow.md).
 
 ## Implementation Status
 

--- a/docs/sikesra/operator-workflow.md
+++ b/docs/sikesra/operator-workflow.md
@@ -1,0 +1,167 @@
+# Operator Workflow
+
+This document describes the current operator-facing SIKESRA admin workflow implemented in `packages/plugins/sikesra/`.
+
+## Scope
+
+Current admin route surface:
+
+- `/_emdash/admin/plugins/sikesra/entities`
+- `/_emdash/admin/plugins/sikesra/verification`
+- `/_emdash/admin/plugins/sikesra/operations`
+
+Current wizard implementation is block-based and progressive. It is implementation-aligned, not an aspirational redesign.
+
+## 8 Data Modules
+
+| Code | Module | Entity Kind | Initial Subtypes | Minimum Required Detail Fields |
+| --- | --- | --- | --- | --- |
+| `01` | Rumah Ibadah | `building` | Masjid, Musholla, Surau, Gereja, Pura, Wihara, Klenteng, Lainnya | `jenis_rumah_ibadah` |
+| `02` | Lembaga Keagamaan | `institution` | Islam, Kristen, Katolik, Hindu, Buddha, Konghucu, Lainnya | `agama` |
+| `03` | Pendidikan Keagamaan | `institution` | TPA/TPQ, Pondok Pesantren, Lainnya | `jenis_pendidikan` |
+| `04` | LKS / Lembaga Kesejahteraan Sosial | `institution` | BAZNAS, PWRI, Panti Asuhan, Panti Yatim, Panti Jompo, Rukun Kematian, Majelis Taklim, LKS Lainnya | `jenis_lks` |
+| `05` | Guru Agama | `person` | Rumahan, Lembaga, Lainnya | `person_profile_id`, `agama`, `status_guru`, `institusi_pengajaran` |
+| `06` | Anak Yatim | `person` | Yatim, Piatu, Yatim Piatu | `person_profile_id`, `kategori_anak`, `hubungan_wali` |
+| `07` | Disabilitas | `person` | Fisik, Intelektual, Mental, Sensorik | `person_profile_id`, `jenis_disabilitas`, `tingkat_keparahan` |
+| `08` | Lansia Terlantar | `person` | Terlantar, Rawan Terlantar, Mandiri dengan Risiko | `person_profile_id`, `status_keterlantaran`, `kondisi_tempat_tinggal` |
+
+Source of truth:
+
+- `packages/plugins/sikesra/src/module-ui-config.ts`
+- `packages/plugins/sikesra/src/detail-modules.ts`
+
+## Current Wizard Steps
+
+The current operator flow is:
+
+1. Pilih modul data SIKESRA.
+2. Pilih subjenis yang sesuai dengan modul.
+3. Isi identitas dasar dan desa/kelurahan.
+4. Simpan draft.
+5. Lengkapi detail modul.
+6. Catat dokumen pendukung.
+7. Jalankan validasi dan review duplikat.
+8. Review ringkasan lalu ajukan verifikasi.
+
+Current block wizard markers shown in the UI:
+
+- `1. Jenis Data`
+- `2. Wilayah`
+- `3. Detail Modul`
+- `4. Dokumen`
+- `5. Validasi`
+- `6. Review`
+- `7. Submit`
+
+## Create Draft Behavior
+
+Current create flow no longer asks operators to type raw module codes without context.
+
+Implemented now:
+
+- module names are shown with readable labels
+- subtype selection is validated against the selected module
+- entity kind is derived from module metadata, not typed by operator
+- official village remains a select
+
+Current guardrail:
+
+- mismatched module/subtype pairs are blocked in the admin flow and backend normalization path
+
+## Person Profile Workflow
+
+For person-based modules (`05` to `08`), the current implementation still uses an interim workflow.
+
+Implemented now:
+
+- operator sees a readable `Person Profile` label
+- helper text explains that the current path uses an existing profile ID
+- sensitive identity values remain server-side masked in normal views
+
+Remaining gap:
+
+- no full search/create/link person-profile UI yet
+
+Follow-up issues:
+
+- `#280` improve person profile UX for person-based modules
+- `#283` improve person profile workflow for person-based modules
+
+## Document Workflow
+
+Current implemented document behavior is intentionally honest about shell limitations.
+
+Implemented now:
+
+- operator no longer types MIME type manually
+- file size is derived from payload when `contentBase64` is provided
+- direct shell path can complete upload metadata and file content together
+- when binary upload is unavailable in the shell, the UI returns a resumable handoff with:
+  - `entityId`
+  - `fileObjectId`
+  - `/_emdash/api/plugins/sikesra/v1/documents/complete`
+
+Current limitation:
+
+- block UI shell still does not provide a native binary file picker/upload control
+- resumable handoff requires an upload-capable client/API caller
+
+## Validation and Duplicate Review
+
+Current validation behavior:
+
+- validation errors are grouped by section
+- field labels are shown in readable Indonesian labels where metadata exists
+- duplicate preview is shown from `awcms_sikesra_duplicate_candidates`
+
+Current submit gate:
+
+- submit is blocked when required validation still fails
+- submit is blocked when live `high` or `blocking` duplicate candidates remain
+- blocked submit attempts are audited
+
+Current next-action guidance in review/submit:
+
+- complete missing required sections
+- inspect duplicate candidates
+- upload supporting documents if SOP requires them
+- submit only when readiness passes
+
+## Security and Privacy Rules
+
+Operators and implementers must keep these rules intact:
+
+- never trust frontend-supplied tenant, site, role, permission, or region scope
+- all normal queries must enforce tenant/site/deleted guards
+- duplicate preview must not expose protected details unsafely
+- raw R2 keys and private file URLs must not be shown in unsafe UI
+- blocked or sensitive actions should remain audited
+
+## Manual Operator Checks
+
+Minimum manual checks for current wizard behavior:
+
+1. Open `/_emdash/admin/plugins/sikesra/entities`.
+2. Start create flow and verify all 8 modules appear.
+3. Choose a module and verify subtype mismatch is rejected.
+4. Create a valid draft and complete required detail fields.
+5. Open documents and verify MIME/size are no longer typed manually.
+6. Run validation and confirm readable section labels appear.
+7. Seed or simulate a high-risk duplicate and verify submit is blocked.
+8. Verify review screen shows the next recommended action.
+
+## Validation Commands
+
+Targeted package checks for the current implementation:
+
+```bash
+cd packages/plugins/sikesra
+pnpm typecheck
+pnpm test -- --runInBand
+```
+
+Workspace baseline note:
+
+- root `pnpm --silent lint:quick` currently fails from repository-wide oxlint config
+- root `pnpm typecheck` currently fails outside SIKESRA in `packages/contentful-to-portable-text`
+- root `pnpm test` currently fails outside SIKESRA in `packages/marketplace`

--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -9,9 +9,12 @@ import {
 	getModuleUiFieldConfig,
 	listModuleUiConfigs,
 } from "./module-ui-config.js";
+import { SIKESRA_API_BASE } from "./shared.js";
 import {
 	completeUpload,
+	estimateBase64SizeBytes,
 	generateUploadUrl,
+	guessMimeTypeFromFilename,
 	getEntityDocuments,
 	validateUploadInput,
 	type CompleteUploadInput,
@@ -69,6 +72,10 @@ interface EntitySubmitReadiness {
 	recommendedAction: string;
 	reasonMessage?: string;
 }
+
+interface AdminDocumentRegisterInput
+	extends GenerateUploadUrlInput,
+		Pick<CompleteUploadInput, "entityId" | "documentType" | "checksumSha256" | "contentBase64"> {}
 
 // ── Admin Page Router ────────────────────────────────────────────────────────
 
@@ -1431,10 +1438,42 @@ async function handleEntityAction(
 		if (entityId) return buildEntityReviewSummary(db, ctx, entityId);
 	}
 	if (actionId === "entities:document_register") {
-		const input = normalizeDocumentRegisterForm(action.values);
-		await registerEntityDocument(db, ctx, input);
-		const step = await buildEntityDocumentStep(db, ctx, input.entityId);
-		return { ...step, toast: { message: "Dokumen berhasil dicatat", type: "success" } };
+		try {
+			const input = normalizeDocumentRegisterForm(action.values);
+			const registered = await registerEntityDocument(db, ctx, input);
+			if (registered.mode === "prepared") {
+				return buildPreparedDocumentUploadStep(db, ctx, input.entityId, {
+					entityId: input.entityId,
+					fileName: input.fileName,
+					documentType: input.documentType,
+					classification: input.classification,
+					mimeType: input.mimeType,
+					fileObjectId: registered.upload.fileObjectId,
+				});
+			}
+			const step = await buildEntityDocumentStep(db, ctx, input.entityId);
+			return { ...step, toast: { message: "Dokumen berhasil dicatat", type: "success" } };
+		} catch (error) {
+			const entityId = typeof action.values?.entityId === "string" ? action.values.entityId : "";
+			const step = entityId ? await buildEntityDocumentStep(db, ctx, entityId) : { blocks: [] };
+			const rawMessage = error instanceof Error ? error.message : "Dokumen tidak valid";
+			const message = rawMessage === "DOCUMENT_REGISTER_INPUT_REQUIRED"
+				? "Nama file, jenis dokumen, dan entity ID wajib diisi."
+				: rawMessage.replace(/^DOCUMENT_REGISTER_INVALID:\s*/, "");
+			return {
+				...step,
+				blocks: [
+					{
+						type: "banner",
+						variant: "error",
+						title: "Dokumen Tidak Valid",
+						description: message,
+					},
+					...step.blocks,
+				],
+				toast: { message: message || "Dokumen tidak valid", type: "error" },
+			};
+		}
 	}
 	if (actionId === "entities:update_section") {
 		const input = normalizeDraftUpdateForm(action.values);
@@ -1907,13 +1946,28 @@ async function buildEntityDocumentStep(
 			...buildEntityWizardSteps(entityId, 4),
 			{ type: "divider" },
 			{
+				type: "banner",
+				variant: "info",
+				title: "Workflow Upload Dokumen",
+				description: "MIME type diturunkan dari nama file dan ukuran dihitung dari payload file yang diberikan di shell ini. Jika shell belum bisa unggah file langsung, gunakan handoff API upload yang aman tanpa mengisi metadata teknis secara manual.",
+			},
+			{
 				type: "form",
 				fields: [
 					{ type: "text_input", action_id: "entityId", label: "Entity ID", value: entityId },
 					{ type: "text_input", action_id: "fileName", label: "Nama File", placeholder: "ktp.pdf" },
-					{ type: "text_input", action_id: "documentType", label: "Jenis Dokumen", placeholder: "ktp / kk / surat_keterangan" },
-					{ type: "text_input", action_id: "mimeType", label: "MIME Type", value: "application/pdf" },
-					{ type: "text_input", action_id: "sizeBytes", label: "Ukuran (bytes)", value: "1024" },
+					{
+						type: "select",
+						action_id: "documentType",
+						label: "Jenis Dokumen",
+						options: [
+							{ label: "KTP", value: "ktp" },
+							{ label: "KK", value: "kk" },
+							{ label: "Surat Keterangan", value: "surat_keterangan" },
+							{ label: "Foto Lokasi", value: "foto_lokasi" },
+							{ label: "Lainnya", value: "lainnya" },
+						],
+					},
 					{
 						type: "select",
 						action_id: "classification",
@@ -1924,9 +1978,16 @@ async function buildEntityDocumentStep(
 							{ label: "Highly Restricted", value: "highly_restricted" },
 						],
 					},
+					{
+						type: "text_input",
+						action_id: "contentBase64",
+						label: "Konten File Base64 (opsional untuk shell ini)",
+						multiline: true,
+						placeholder: "Tempel base64 file untuk simulasi/testing, atau kosongkan untuk menyiapkan upload URL.",
+					},
 					{ type: "text_input", action_id: "checksumSha256", label: "Checksum SHA256", placeholder: "opsional" },
 				],
-				submit: { label: "Catat Dokumen", action_id: "entities:document_register" },
+				submit: { label: "Siapkan / Catat Dokumen", action_id: "entities:document_register" },
 			},
 			{ type: "divider" },
 			...(documents.length === 0
@@ -2329,11 +2390,13 @@ function normalizeEntityLifecycleForm(values: Record<string, unknown> | undefine
 }
 
 function normalizeDocumentRegisterForm(values: Record<string, unknown> | undefined):
-	GenerateUploadUrlInput &
-	Pick<CompleteUploadInput, "entityId" | "documentType" | "checksumSha256"> {
+	AdminDocumentRegisterInput {
 	const fileName = typeof values?.fileName === "string" ? values.fileName : "";
-	const mimeType = typeof values?.mimeType === "string" ? values.mimeType : "application/pdf";
-	const sizeBytesRaw = typeof values?.sizeBytes === "string" ? Number(values.sizeBytes) : values?.sizeBytes;
+	const mimeType = guessMimeTypeFromFilename(fileName) ?? "";
+	const contentBase64 =
+		typeof values?.contentBase64 === "string" && values.contentBase64.trim()
+			? values.contentBase64.trim()
+			: undefined;
 	const classification =
 		typeof values?.classification === "string"
 			? (values.classification as DocumentClassification)
@@ -2343,16 +2406,18 @@ function normalizeDocumentRegisterForm(values: Record<string, unknown> | undefin
 	const input = {
 		fileName,
 		mimeType,
-		sizeBytes: typeof sizeBytesRaw === "number" && Number.isFinite(sizeBytesRaw) ? sizeBytesRaw : 0,
+		sizeBytes: contentBase64 ? estimateBase64SizeBytes(contentBase64) : 0,
 		classification,
 		entityId,
 		documentType,
+		contentBase64,
 		checksumSha256:
 			typeof values?.checksumSha256 === "string" && values.checksumSha256
 				? values.checksumSha256
 				: undefined,
 	};
 	if (!entityId || !documentType) throw new Error("DOCUMENT_REGISTER_INPUT_REQUIRED");
+	if (!mimeType) throw new Error("DOCUMENT_REGISTER_INVALID: Tipe file belum didukung dari nama file yang diberikan.");
 	const errors = validateUploadInput(input);
 	if (errors.length > 0) throw new Error(`DOCUMENT_REGISTER_INVALID: ${errors.join("; ")}`);
 	return input;
@@ -2361,9 +2426,16 @@ function normalizeDocumentRegisterForm(values: Record<string, unknown> | undefin
 async function registerEntityDocument(
 	db: unknown,
 	ctx: SikesraRequestContext,
-	input: GenerateUploadUrlInput & Pick<CompleteUploadInput, "entityId" | "documentType" | "checksumSha256">,
-) {
+	input: AdminDocumentRegisterInput,
+): Promise<{ mode: "prepared" | "completed"; upload: UploadUrlResponse }> {
 	const runtime = buildAdminDocumentRuntime(db);
+	if (!input.contentBase64) {
+		const upload = await generateUploadUrl(input, ctx, runtime);
+		return {
+			mode: "prepared",
+			upload,
+		};
+	}
 	const upload = await generateUploadUrl(input, ctx, runtime);
 	await completeUpload(
 		{
@@ -2371,6 +2443,7 @@ async function registerEntityDocument(
 			entityId: input.entityId,
 			documentType: input.documentType,
 			classification: input.classification,
+			contentBase64: input.contentBase64,
 			checksumSha256: input.checksumSha256,
 			originalFilename: input.fileName,
 			mimeType: input.mimeType,
@@ -2379,7 +2452,47 @@ async function registerEntityDocument(
 		ctx,
 		runtime,
 	);
-	return upload;
+	return { mode: "completed", upload };
+}
+
+async function buildPreparedDocumentUploadStep(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	entityId: string,
+	prepared: {
+		entityId: string;
+		fileName: string;
+		documentType: string;
+		classification: string;
+		mimeType: string;
+		fileObjectId: string;
+	},
+): Promise<BlockResponse> {
+	const step = await buildEntityDocumentStep(db, ctx, entityId);
+	return {
+		blocks: [
+			{
+				type: "banner",
+				variant: "info",
+				title: "Handoff Upload API",
+				description: "Shell admin ini belum mengunggah file biner langsung. Gunakan fileObjectId berikut pada klien/API yang mendukung upload, lalu panggil endpoint complete dengan MIME type, sizeBytes, dan payload file sebenarnya untuk menyimpan metadata akhir dan audit.",
+			},
+			{
+				type: "fields",
+				fields: [
+					{ label: "Entity ID", value: prepared.entityId },
+					{ label: "Nama File", value: prepared.fileName },
+					{ label: "Jenis Dokumen", value: prepared.documentType },
+					{ label: "Klasifikasi", value: prepared.classification },
+					{ label: "MIME Type", value: prepared.mimeType },
+					{ label: "File Object ID", value: prepared.fileObjectId },
+					{ label: "API Complete Upload", value: `${SIKESRA_API_BASE}/v1/documents/complete` },
+				],
+			},
+			...step.blocks,
+		],
+				toast: { message: "Handoff upload siap digunakan", type: "info" },
+			};
 }
 
 function buildModuleDetailFields(

--- a/packages/plugins/sikesra/src/document.ts
+++ b/packages/plugins/sikesra/src/document.ts
@@ -122,6 +122,17 @@ export interface DocumentStorageContext {
 	};
 }
 
+const FILENAME_MIME_MAP: Record<string, string> = {
+	".pdf": "application/pdf",
+	".jpg": "image/jpeg",
+	".jpeg": "image/jpeg",
+	".png": "image/png",
+	".doc": "application/msword",
+	".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+	".xls": "application/vnd.ms-excel",
+	".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+};
+
 const ALLOWED_MIME_TYPES = new Set([
 	"application/pdf",
 	"image/jpeg",
@@ -152,6 +163,19 @@ export function validateUploadInput(input: GenerateUploadUrlInput): string[] {
 		errors.push(`Invalid classification: ${input.classification}.`);
 	}
 	return errors;
+}
+
+export function guessMimeTypeFromFilename(fileName: string): string | null {
+	const normalized = fileName.trim().toLowerCase();
+	const extension = normalized.includes(".") ? normalized.slice(normalized.lastIndexOf(".")) : "";
+	return FILENAME_MIME_MAP[extension] ?? null;
+}
+
+export function estimateBase64SizeBytes(contentBase64: string): number {
+	const normalized = contentBase64.replace(/\s+/g, "");
+	if (!normalized) return 0;
+	const padding = normalized.endsWith("==") ? 2 : normalized.endsWith("=") ? 1 : 0;
+	return Math.max(0, Math.floor((normalized.length * 3) / 4) - padding);
 }
 
 export async function generateUploadUrl(
@@ -188,7 +212,7 @@ export async function generateUploadUrl(
 	}
 
 	return {
-		uploadUrl: `/_emdash/api/plugins/sikesra/v1/documents/${fileObjectId}/upload`,
+		uploadUrl: `/_emdash/api/plugins/sikesra/v1/documents/complete`,
 		fileObjectId,
 	};
 }

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -196,9 +196,8 @@ describe("SIKESRA admin entity workflow", () => {
 				entityId: "entity-doc",
 				fileName: "ktp.pdf",
 				documentType: "ktp",
-				mimeType: "application/pdf",
-				sizeBytes: "1024",
 				classification: "restricted",
+				contentBase64: Buffer.from("pdf-data", "utf8").toString("base64"),
 			},
 		});
 		const stored = await sql<{ total: number }>`
@@ -210,11 +209,118 @@ describe("SIKESRA admin entity workflow", () => {
 		expect(documentStep.blocks).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ type: "header", text: "Dokumen Pendukung" }),
+				expect.objectContaining({ type: "banner", title: "Workflow Upload Dokumen" }),
 				expect.objectContaining({ type: "form" }),
 			]),
 		);
+		const formBlock = documentStep.blocks.find((block) => block.type === "form");
+		const formFields = Array.isArray(formBlock?.fields) ? formBlock.fields : [];
+		expect(formFields.find((field) => field.action_id === "mimeType")).toBeUndefined();
+		expect(formFields.find((field) => field.action_id === "sizeBytes")).toBeUndefined();
+		expect(formFields.find((field) => field.action_id === "contentBase64")).toEqual(
+			expect.objectContaining({ label: "Konten File Base64 (opsional untuk shell ini)" }),
+		);
 		expect(registered.toast).toEqual({ message: "Dokumen berhasil dicatat", type: "success" });
 		expect(stored.rows[0]?.total).toBe(1);
+	});
+
+	it("prepares a guided upload handoff when file content is not provided", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-doc-prep', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Upload', '6201011001', 'local-1', 'Jl. Upload', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+		`);
+
+		const prepared = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: {
+				action_id: "entities:document_register",
+				entityId: "entity-doc-prep",
+				fileName: "kk.pdf",
+				documentType: "kk",
+				classification: "restricted",
+			},
+		});
+		const pendingFiles = await sql<{ total: number; id: string | null }>`
+			SELECT COUNT(*) as total, MAX(id) as id
+			FROM awcms_sikesra_file_objects
+			WHERE tenant_id = 'tenant-1' AND site_id = 'site-1'
+		`.execute(db);
+
+		expect(prepared.toast).toEqual({ message: "Handoff upload siap digunakan", type: "info" });
+		expect(prepared.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "banner", title: "Handoff Upload API" }),
+				expect.objectContaining({ type: "fields" }),
+			]),
+		);
+		const handoffFields = prepared.blocks.find((block) => block.type === "fields");
+		expect(handoffFields).toEqual(
+			expect.objectContaining({
+				fields: expect.arrayContaining([
+					expect.objectContaining({ label: "Entity ID", value: "entity-doc-prep" }),
+					expect.objectContaining({ label: "File Object ID", value: expect.stringContaining("doc_") }),
+					expect.objectContaining({ label: "API Complete Upload", value: expect.stringContaining("/v1/documents/complete") }),
+				]),
+			}),
+		);
+		expect(pendingFiles.rows[0]?.total).toBe(1);
+		expect(pendingFiles.rows[0]?.id).toContain("doc_");
+	});
+
+	it("keeps invalid file-name errors inside the document step", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-doc-invalid', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Invalid', '6201011001', 'local-1', 'Jl. Invalid', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+		`);
+
+		const invalid = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: {
+				action_id: "entities:document_register",
+				entityId: "entity-doc-invalid",
+				fileName: "scan.heic",
+				documentType: "kk",
+				classification: "restricted",
+			},
+		});
+
+		expect(invalid.toast).toEqual({
+			message: "Tipe file belum didukung dari nama file yang diberikan.",
+			type: "error",
+		});
+		expect(invalid.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "banner", title: "Dokumen Tidak Valid" }),
+				expect.objectContaining({ type: "header", text: "Dokumen Pendukung" }),
+			]),
+		);
+	});
+
+	it("shows a friendly required-input error for incomplete document handoff forms", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-doc-missing', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Missing', '6201011001', 'local-1', 'Jl. Missing', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+		`);
+
+		const missing = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: {
+				action_id: "entities:document_register",
+				entityId: "entity-doc-missing",
+				fileName: "ktp.pdf",
+				classification: "restricted",
+			},
+		});
+
+		expect(missing.toast).toEqual({
+			message: "Nama file, jenis dokumen, dan entity ID wajib diisi.",
+			type: "error",
+		});
+		expect(missing.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "banner", title: "Dokumen Tidak Valid" }),
+			]),
+		);
 	});
 
 	it("shows operator-friendly module choices in create flow and registry filters", async () => {

--- a/packages/plugins/sikesra/tests/document.test.ts
+++ b/packages/plugins/sikesra/tests/document.test.ts
@@ -6,7 +6,9 @@ import { describe, expect, it } from "vitest";
 
 import {
 	completeUpload,
+	estimateBase64SizeBytes,
 	generateUploadUrl,
+	guessMimeTypeFromFilename,
 	getDocumentDownload,
 	getEntityDocuments,
 	replaceDocument,
@@ -129,6 +131,13 @@ function makeContext() {
 }
 
 describe("SIKESRA document workflow", () => {
+	it("derives mime type and base64 size from uploaded file metadata", () => {
+		expect(guessMimeTypeFromFilename("ktp.pdf")).toBe("application/pdf");
+		expect(guessMimeTypeFromFilename("foto.JPG")).toBe("image/jpeg");
+		expect(guessMimeTypeFromFilename("unknown.bin")).toBeNull();
+		expect(estimateBase64SizeBytes(Buffer.from("pdf-data", "utf8").toString("base64"))).toBe(8);
+	});
+
 	it("rejects invalid mime types", async () => {
 		await expect(
 			generateUploadUrl(
@@ -156,6 +165,7 @@ describe("SIKESRA document workflow", () => {
 			ctx,
 			runtime,
 		);
+		expect(upload.uploadUrl).toContain("/_emdash/api/plugins/sikesra/v1/documents/complete");
 		const completed = await completeUpload(
 			{
 				fileObjectId: upload.fileObjectId,


### PR DESCRIPTION
## What does this PR do?

Adds an implementation-aligned operator workflow reference for the current 8-module SIKESRA wizard and links the core SIKESRA docs to it.

Closes #286

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- Docs-only change.
- Readability and changed-file diff were checked locally.
- Root repo lint/typecheck/test blockers remain unchanged outside this docs slice.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4
