### PR TITLE
feat: add sikesra-only validation mode

### DIFF
--- a/demos/cloudflare/astro.config.mjs
+++ b/demos/cloudflare/astro.config.mjs
@@ -15,6 +15,19 @@ import { webhookNotifierPlugin } from "@emdash-cms/plugin-webhook-notifier";
 import { defineConfig, fontProviders } from "astro/config";
 import emdash from "emdash/astro";
 
+function isPluginEnabled(pluginId) {
+	const raw = process.env.AWCMS_ENABLED_PLUGINS ?? "";
+	const enabled = raw
+		.split(",")
+		.map((item) => item.trim())
+		.filter(Boolean);
+	if (enabled.length === 0) return true;
+	return enabled.includes(pluginId);
+}
+
+const plugins = [isPluginEnabled("sikesra") ? sikesraPlugin() : null, isPluginEnabled("forms") ? formsPlugin() : null].filter(Boolean);
+const sandboxedPlugins = [isPluginEnabled("webhook-notifier") ? webhookNotifierPlugin() : null].filter(Boolean);
+
 export default defineConfig({
 	output: "server",
 	adapter: cloudflare({
@@ -35,7 +48,7 @@ export default defineConfig({
 	},
 	integrations: [
 		react(),
-		emdash({
+			emdash({
 			// D1 database - binding name must match wrangler.jsonc
 			// session: "auto" enables read replicas (nearest replica for anon,
 			// bookmark-based consistency for authenticated users)
@@ -57,13 +70,9 @@ export default defineConfig({
 				}),
 			],
 			// Trusted plugins (run in host worker)
-			plugins: [
-				sikesraPlugin(),
-				// Test plugin that exercises all v2 APIs
-				formsPlugin(),
-			],
-			// Sandboxed plugins (run in isolated workers)
-			sandboxed: [webhookNotifierPlugin()],
+				plugins,
+				// Sandboxed plugins (run in isolated workers)
+				sandboxed: sandboxedPlugins,
 			// Sandbox runner for Cloudflare
 			sandboxRunner: sandbox(),
 			// Plugin marketplace

--- a/demos/plugins-demo/README.md
+++ b/demos/plugins-demo/README.md
@@ -62,6 +62,29 @@ pnpm dev
 open http://localhost:4321
 ```
 
+## SIKESRA-only Validation Mode
+
+To validate only the SIKESRA plugin surface without loading the other demo plugins:
+
+```bash
+AWCMS_ENABLED_PLUGINS=sikesra pnpm dev
+```
+
+Expected result in this mode:
+
+- admin navigation only shows SIKESRA plugin pages
+- non-SIKESRA plugin pages do not appear
+- `/sikesra` and `/_emdash/admin/plugins/sikesra/*` remain available
+
+Rollback to normal multi-plugin demo behavior:
+
+```bash
+unset AWCMS_ENABLED_PLUGINS
+pnpm dev
+```
+
+Or simply start the demo without `AWCMS_ENABLED_PLUGINS` set.
+
 ## Testing Plugin Hooks
 
 1. Open the admin at `http://localhost:4321/_emdash/admin`

--- a/demos/plugins-demo/astro.config.mjs
+++ b/demos/plugins-demo/astro.config.mjs
@@ -9,21 +9,33 @@ import { webhookNotifierPlugin } from "@emdash-cms/plugin-webhook-notifier";
 import { defineConfig } from "astro/config";
 import emdash from "emdash/astro";
 
+function isPluginEnabled(pluginId) {
+	const raw = process.env.AWCMS_ENABLED_PLUGINS ?? "";
+	const enabled = raw
+		.split(",")
+		.map((item) => item.trim())
+		.filter(Boolean);
+	if (enabled.length === 0) return true;
+	return enabled.includes(pluginId);
+}
+
+const plugins = [
+	isPluginEnabled("sikesra") ? sikesraPlugin() : null,
+	isPluginEnabled("audit-log") ? auditLogPlugin() : null,
+	isPluginEnabled("webhook-notifier") ? webhookNotifierPlugin() : null,
+	isPluginEnabled("embeds") ? embedsPlugin() : null,
+	isPluginEnabled("api-test") ? apiTestPlugin() : null,
+].filter(Boolean);
+
 export default defineConfig({
 	output: "server",
 	adapter: cloudflare(),
 	integrations: [
 		react(),
-		emdash({
-			database: d1({ binding: "DB", session: "auto" }),
-			storage: r2({ binding: "MEDIA" }),
-			plugins: [
-				sikesraPlugin(),
-				auditLogPlugin(),
-				webhookNotifierPlugin(),
-				embedsPlugin(),
-				apiTestPlugin(),
-			],
-		}),
-	],
+			emdash({
+				database: d1({ binding: "DB", session: "auto" }),
+				storage: r2({ binding: "MEDIA" }),
+				plugins,
+			}),
+		],
 });


### PR DESCRIPTION
## What does this PR do?

Adds a reversible `AWCMS_ENABLED_PLUGINS` mode for the validation/demo targets so they can run with only the SIKESRA plugin enabled.

Closes #297

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- No EmDash core files were modified.
- This mode is config-only and rollback-friendly: unset `AWCMS_ENABLED_PLUGINS` to restore normal multi-plugin behavior.
- Required validation commands for `@ahliweb/plugin-sikesra` passed:
  - `pnpm --filter @ahliweb/plugin-sikesra typecheck`
  - `pnpm --filter @ahliweb/plugin-sikesra test`
  - `pnpm --filter @ahliweb/plugin-sikesra build`

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4
