### PR TITLE
fix: use real entity id in registry actions

### DIFF
--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -1339,8 +1339,8 @@ async function buildEntityList(
 		blocks.push({
 			type: "table",
 			columns: [
-				{ key: "entityId", label: "Entity ID", format: "text" },
-				{ key: "id", label: "ID SIKESRA", format: "code" },
+				{ key: "id", label: "Entity ID", format: "text" },
+				{ key: "sikesraId", label: "ID SIKESRA", format: "code" },
 				{ key: "type", label: "Tipe", format: "badge" },
 				{ key: "displayName", label: "Nama", format: "text" },
 				{ key: "statusData", label: "Status Data", format: "badge" },
@@ -1350,8 +1350,8 @@ async function buildEntityList(
 				{ key: "actions", label: "Aksi", format: "text" },
 			],
 			rows: result.items.map((row) => ({
-				entityId: row.id,
-				id: row.sikesraId20 ?? row.id.slice(0, 12),
+				id: row.id,
+				sikesraId: row.sikesraId20 ?? row.id.slice(0, 12),
 				type: `${row.objectTypeName} / ${row.objectSubtypeName}`,
 				displayName: row.displayName,
 				statusData: row.statusData,
@@ -2354,7 +2354,7 @@ function parseEntityFilters(values: Record<string, unknown> | undefined): Entity
 
 function getActionEntityId(values: Record<string, unknown> | undefined) {
 	if (typeof values?.entityId === "string" && values.entityId) return values.entityId;
-	if (typeof values?.id === "string" && values.id.startsWith("ent_")) return values.id;
+	if (typeof values?.id === "string" && values.id) return values.id;
 	return undefined;
 }
 

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -371,6 +371,39 @@ describe("SIKESRA admin entity workflow", () => {
 		);
 	});
 
+	it("opens the correct entity detail from a Registry row using the real entity ID payload", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-registry-1', 'tenant-1', 'site-1', '62010110010101000999', '01', '01', 'building', 'Masjid Registry', '6201011001', 'local-1', 'Jl. Registry', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+			INSERT INTO awcms_sikesra_rumah_ibadah_details VALUES
+			('detail-registry-1', 'tenant-1', 'site-1', 'entity-registry-1', 'Masjid', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '2026-01-01', '2026-01-02', NULL, 'admin-1', 'admin-1');
+		`);
+
+		const registry = await buildAdminPage(db, makeContext(), "/entities");
+		const tableBlock = registry.blocks.find((block) => block.type === "table");
+		const rows = Array.isArray(tableBlock?.rows) ? tableBlock.rows : [];
+		const targetRow = rows.find((row) => row.displayName === "Masjid Registry");
+
+		expect(targetRow).toEqual(
+			expect.objectContaining({
+				id: "entity-registry-1",
+				sikesraId: "62010110010101000999",
+			}),
+		);
+
+		const detail = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "block_action",
+			values: { action_id: "entities:view", id: "entity-registry-1" },
+		});
+
+		expect(detail.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "header", text: "Masjid Registry" }),
+				expect.objectContaining({ type: "context", text: "ID: 62010110010101000999" }),
+			]),
+		);
+	});
+
 	it.each([
 		{
 			objectTypeCode: "05",


### PR DESCRIPTION
## What does this PR do?

Fixes the SIKESRA Registry row payload so detail actions always use the real primary entity ID, while the user-facing SIKESRA ID remains a display field.

Closes #298

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- Required validation commands for `@ahliweb/plugin-sikesra` passed:
  - `pnpm --filter @ahliweb/plugin-sikesra typecheck`
  - `pnpm --filter @ahliweb/plugin-sikesra test`
  - `pnpm --filter @ahliweb/plugin-sikesra build`

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4
