### PR TITLE
feat: add inline person profile workflow

### DIFF
--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -1477,6 +1477,9 @@ async function handleEntityAction(
 	}
 	if (actionId === "entities:update_section") {
 		const input = normalizeDraftUpdateForm(action.values);
+		if (input.section === "details") {
+			input.patch = await preparePersonProfilePatch(db, ctx, input.entityId, input.patch);
+		}
 		await updateDraft(db, ctx, input);
 		const detail = await buildEntityDetail(db, ctx, input.entityId);
 		return { ...detail, toast: { message: "Draft berhasil diperbarui", type: "success" } };
@@ -1838,6 +1841,10 @@ async function buildEntityEditForm(
 	const detailModule = getDetailModuleConfig(detail.entity.objectTypeCode);
 	const moduleUi = getModuleUiConfig(detail.entity.objectTypeCode);
 	const subtypeOptions = getModuleSubtypeOptions(detail.entity.objectTypeCode);
+	const personProfileWorkflowFields =
+		section === "details" && moduleUi?.entityKind === "person"
+			? buildPersonProfileInputFields(detail)
+			: [];
 	const fields =
 		section === "identity"
 			? [
@@ -1868,7 +1875,7 @@ async function buildEntityEditForm(
 						{ type: "text_input", action_id: "local_region_id", label: "Local Region ID", value: detail.entity.localRegion?.id ?? "" },
 						{ type: "text_input", action_id: "address_text", label: "Alamat", multiline: true, value: (detail.summary.addressText as string | null) ?? "" },
 					]
-				: buildModuleDetailFields(detail.entity.objectTypeCode, detail.details, detailModule?.fields ?? []);
+				: [...personProfileWorkflowFields, ...buildModuleDetailFields(detail.entity.objectTypeCode, detail.details, detailModule?.fields ?? [])];
 
 	return {
 		blocks: [
@@ -2297,6 +2304,53 @@ async function auditBlockedSubmitAttempt(
 	}
 }
 
+async function preparePersonProfilePatch(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	entityId: string,
+	patch: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	const detail = await getEntityDetail(db, ctx, entityId);
+	if (detail.entity.entityKind !== "person") {
+		const { person_profile_mode: _mode, person_profile_full_name: _fullName, ...rest } = patch;
+		return rest;
+	}
+
+	const mode = typeof patch.person_profile_mode === "string" ? patch.person_profile_mode : "create_inline";
+	const { person_profile_mode: _mode, person_profile_full_name: _fullName, ...rest } = patch;
+
+	if (mode !== "create_inline") {
+		return rest;
+	}
+
+	const existingProfileId = typeof rest.person_profile_id === "string" ? rest.person_profile_id.trim() : "";
+	if (existingProfileId) {
+		return { ...rest, person_profile_id: existingProfileId };
+	}
+
+	const fullNameRaw = typeof patch.person_profile_full_name === "string" ? patch.person_profile_full_name.trim() : "";
+	const fullName = fullNameRaw || detail.entity.displayName;
+	const personProfileId = `person_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+	await sql`
+		INSERT INTO awcms_sikesra_person_profiles (
+			id,
+			tenant_id,
+			site_id,
+			full_name,
+			deleted_at
+		) VALUES (
+			${personProfileId},
+			${ctx.tenantId},
+			${ctx.siteId},
+			${fullName},
+			${null}
+		)
+	`.execute(db as never);
+
+	return { ...rest, person_profile_id: personProfileId };
+}
+
 async function buildEntityLifecycleForm(
 	db: unknown,
 	ctx: SikesraRequestContext,
@@ -2541,6 +2595,32 @@ function buildModuleDetailFields(
 	});
 }
 
+function buildPersonProfileInputFields(detail: Awaited<ReturnType<typeof getEntityDetail>>): Block[] {
+	const existingProfileId =
+		typeof detail.details?.person_profile_id === "string" ? detail.details.person_profile_id : "";
+	return [
+		{
+			type: "select",
+			action_id: "person_profile_mode",
+			label: "Aksi Profil Orang",
+			value: existingProfileId ? "link_existing" : "create_inline",
+			options: [
+				{ label: "Buat profil orang dari form ini", value: "create_inline" },
+				{ label: "Tautkan profil yang sudah ada", value: "link_existing" },
+			],
+			description: "Pilih pembuatan profil inline untuk menghindari pengisian ID teknis secara manual.",
+		},
+		{
+			type: "text_input",
+			action_id: "person_profile_full_name",
+			label: "Nama Lengkap Profil Orang",
+			value: detail.entity.displayName,
+			placeholder: "Kosongkan untuk memakai Nama Tampilan entitas",
+			description: "Dipakai saat memilih buat profil orang dari form ini.",
+		},
+	];
+}
+
 function buildPersonProfileWorkflowBlocks(objectTypeCode: string): Block[] {
 	const profileLabel = getReadableFieldLabel(objectTypeCode, "person_profile_id");
 	const helperText = getModuleUiFieldConfig(objectTypeCode, "person_profile_id")?.helperText ?? "";
@@ -2552,14 +2632,14 @@ function buildPersonProfileWorkflowBlocks(objectTypeCode: string): Block[] {
 			type: "banner",
 			variant: "info",
 			title: "Status Implementasi Saat Ini",
-			description: `${profileLabel} masih memakai ID profil yang sudah ada sebagai jalur utama. Pencarian dan pembuatan profil baru belum tersedia langsung di shell admin ini.`,
+			description: `${profileLabel} sekarang bisa dibuat inline dari form detail, atau ditautkan ke profil yang sudah ada bila operator sudah mengetahui ID-nya. Pencarian profil yang sudah ada masih belum tersedia langsung di shell admin ini.`,
 		},
 		{
 			type: "fields",
 			fields: [
 				{ label: "Link profil yang sudah ada", value: `Didukung sekarang melalui field ${profileLabel}` },
+				{ label: "Buat profil orang dari form ini", value: "Didukung sekarang tanpa perlu mengetik ID teknis manual" },
 				{ label: "Cari profil yang sudah ada", value: "Belum tersedia langsung di shell admin ini" },
-				{ label: "Buat profil orang baru", value: "Belum tersedia langsung di shell admin ini" },
 				{ label: "Catatan", value: helperText },
 			],
 		},

--- a/packages/plugins/sikesra/src/module-ui-config.ts
+++ b/packages/plugins/sikesra/src/module-ui-config.ts
@@ -183,7 +183,7 @@ export const SIKESRA_MODULE_UI_CONFIG: readonly ModuleUiConfig[] = [
 			{ code: "99", label: "Lainnya" },
 		],
 		detailFields: [
-			{ key: "person_profile_id", label: "Profil Orang", input: "text", required: true, helperText: "Masukkan ID profil orang yang sudah ada. Pencarian dan pembuatan profil baru belum tersedia langsung di shell admin ini." },
+			{ key: "person_profile_id", label: "Profil Orang", input: "text", required: true, helperText: "Isi ID profil orang hanya jika memilih tautkan profil yang sudah ada. Untuk alur cepat, gunakan pembuatan profil inline di form detail." },
 			{ key: "agama", label: "Agama", input: "select", required: true, options: [
 				{ label: "Islam", value: "Islam" },
 				{ label: "Kristen", value: "Kristen" },
@@ -217,7 +217,7 @@ export const SIKESRA_MODULE_UI_CONFIG: readonly ModuleUiConfig[] = [
 			{ code: "03", label: "Yatim Piatu" },
 		],
 		detailFields: [
-			{ key: "person_profile_id", label: "Profil Orang", input: "text", required: true, helperText: "Masukkan ID profil orang yang sudah ada. Detail identitas sensitif tetap dimask server-side." },
+			{ key: "person_profile_id", label: "Profil Orang", input: "text", required: true, helperText: "Isi ID profil orang hanya jika memilih tautkan profil yang sudah ada. Detail identitas sensitif tetap dimask server-side." },
 			{ key: "kategori_anak", label: "Kategori Anak", input: "select", required: true, options: [
 				{ label: "Yatim", value: "yatim" },
 				{ label: "Piatu", value: "piatu" },
@@ -244,7 +244,7 @@ export const SIKESRA_MODULE_UI_CONFIG: readonly ModuleUiConfig[] = [
 			{ code: "04", label: "Sensorik" },
 		],
 		detailFields: [
-			{ key: "person_profile_id", label: "Profil Orang", input: "text", required: true, helperText: "Masukkan ID profil orang yang sudah ada. Detail sensitif tidak akan ditampilkan penuh pada review umum." },
+			{ key: "person_profile_id", label: "Profil Orang", input: "text", required: true, helperText: "Isi ID profil orang hanya jika memilih tautkan profil yang sudah ada. Detail sensitif tidak akan ditampilkan penuh pada review umum." },
 			{ key: "jenis_disabilitas", label: "Jenis Disabilitas", input: "select", required: true, options: [
 				{ label: "Fisik", value: "Fisik" },
 				{ label: "Intelektual", value: "Intelektual" },
@@ -275,7 +275,7 @@ export const SIKESRA_MODULE_UI_CONFIG: readonly ModuleUiConfig[] = [
 			{ code: "03", label: "Mandiri dengan Risiko" },
 		],
 		detailFields: [
-			{ key: "person_profile_id", label: "Profil Orang", input: "text", required: true, helperText: "Masukkan ID profil orang yang sudah ada. Workflow pencarian dan pembuatan profil baru masih akan ditingkatkan." },
+			{ key: "person_profile_id", label: "Profil Orang", input: "text", required: true, helperText: "Isi ID profil orang hanya jika memilih tautkan profil yang sudah ada. Pembuatan profil inline tersedia, sedangkan pencarian profil masih akan ditingkatkan." },
 			{ key: "status_keterlantaran", label: "Status Keterlantaran", input: "select", required: true, options: [
 				{ label: "Terlantar", value: "terlantar" },
 				{ label: "Rawan Terlantar", value: "rawan_terlantar" },

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
 			completeness_percent INTEGER, duplicate_status TEXT, source_input TEXT, created_at TEXT, updated_at TEXT,
 			verified_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT
 		);
-		CREATE TABLE awcms_sikesra_person_profiles (id TEXT);
+		CREATE TABLE awcms_sikesra_person_profiles (id TEXT, tenant_id TEXT, site_id TEXT, full_name TEXT, deleted_at TEXT);
 		CREATE TABLE awcms_sikesra_code_sequences (id TEXT, tenant_id TEXT, site_id TEXT, official_village_code TEXT, object_type_code TEXT, object_subtype_code TEXT, last_sequence INTEGER, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
 		CREATE TABLE awcms_sikesra_audit_logs (id TEXT, tenant_id TEXT, site_id TEXT, actor_id TEXT, actor_role TEXT, action TEXT, resource_type TEXT, resource_id TEXT, request_id TEXT, success INTEGER, reason TEXT, before_json TEXT, after_json TEXT, ip_address TEXT, user_agent TEXT, created_at TEXT);
 		CREATE TABLE awcms_sikesra_rumah_ibadah_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, jenis_rumah_ibadah TEXT, status_pembangunan TEXT, luas_bangunan REAL, luas_tanah REAL, kapasitas_jamaah INTEGER, tahun_didirikan INTEGER, imam_nama TEXT, pengurus_nama TEXT, kegiatan_rutin TEXT, sumber_dana TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
@@ -462,6 +462,8 @@ describe("SIKESRA admin entity workflow", () => {
 		});
 		const detailForm = detailEdit.blocks.find((block) => block.type === "form");
 		const detailFields = Array.isArray(detailForm?.fields) ? detailForm.fields : [];
+		const personProfileModeField = detailFields.find((field) => field.action_id === "person_profile_mode");
+		const personProfileFullNameField = detailFields.find((field) => field.action_id === "person_profile_full_name");
 		const personProfileField = detailFields.find((field) => field.action_id === "person_profile_id");
 		const exampleDomainField = detailFields.find((field) => field.label === scenario.expectedLabel);
 		const workflowFields = detailEdit.blocks.find((block) => block.type === "fields" && Array.isArray(block.fields) && block.fields.some((field) => field.label === "Link profil yang sudah ada"));
@@ -478,16 +480,126 @@ describe("SIKESRA admin entity workflow", () => {
 				description: expect.stringContaining("Wajib diisi."),
 			}),
 		);
+		expect(personProfileModeField).toEqual(
+			expect.objectContaining({
+				label: "Aksi Profil Orang",
+				type: "select",
+			}),
+		);
+		expect(personProfileFullNameField).toEqual(
+			expect.objectContaining({
+				label: "Nama Lengkap Profil Orang",
+			}),
+		);
 		expect(workflowFields).toEqual(
 			expect.objectContaining({
 				fields: expect.arrayContaining([
 					expect.objectContaining({ label: "Link profil yang sudah ada", value: expect.stringContaining("Profil Orang") }),
+					expect.objectContaining({ label: "Buat profil orang dari form ini", value: "Didukung sekarang tanpa perlu mengetik ID teknis manual" }),
 					expect.objectContaining({ label: "Cari profil yang sudah ada", value: "Belum tersedia langsung di shell admin ini" }),
-					expect.objectContaining({ label: "Buat profil orang baru", value: "Belum tersedia langsung di shell admin ini" }),
 				]),
 			}),
 		);
 		expect(exampleDomainField).toBeDefined();
+	});
+
+	it.each([
+		{
+			objectTypeCode: "05",
+			entityId: "entity-inline-guru",
+			displayName: "Guru Inline",
+			detailTable: "awcms_sikesra_guru_agama_details",
+			patch: {
+				person_profile_mode: "create_inline",
+				person_profile_full_name: "Guru Inline",
+				agama: "Islam",
+				status_guru: "aktif",
+				institusi_pengajaran: "Madrasah Inline",
+			},
+		},
+		{
+			objectTypeCode: "06",
+			entityId: "entity-inline-anak",
+			displayName: "Anak Inline",
+			detailTable: "awcms_sikesra_anak_yatim_details",
+			patch: {
+				person_profile_mode: "create_inline",
+				person_profile_full_name: "Anak Inline",
+				kategori_anak: "yatim",
+				hubungan_wali: "Paman",
+			},
+		},
+		{
+			objectTypeCode: "07",
+			entityId: "entity-inline-disabilitas",
+			displayName: "Disabilitas Inline",
+			detailTable: "awcms_sikesra_disabilitas_details",
+			patch: {
+				person_profile_mode: "create_inline",
+				person_profile_full_name: "Disabilitas Inline",
+				jenis_disabilitas: "Sensorik",
+				tingkat_keparahan: "sedang",
+			},
+		},
+		{
+			objectTypeCode: "08",
+			entityId: "entity-inline-lansia",
+			displayName: "Lansia Inline",
+			detailTable: "awcms_sikesra_lansia_terlantar_details",
+			patch: {
+				person_profile_mode: "create_inline",
+				person_profile_full_name: "Lansia Inline",
+				status_keterlantaran: "terlantar",
+				kondisi_tempat_tinggal: "Rumah sederhana",
+			},
+		},
+	])("creates person profiles inline for module $objectTypeCode through the admin detail flow", async (scenario) => {
+		sqlite.exec(`
+			CREATE TABLE awcms_sikesra_guru_agama_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, person_profile_id TEXT, agama TEXT, status_guru TEXT, bidang_pengajaran TEXT, institusi_pengajaran TEXT, jumlah_murid INTEGER, pendidikan_terakhir TEXT, sertifikasi TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+			CREATE TABLE awcms_sikesra_anak_yatim_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, person_profile_id TEXT, kategori_anak TEXT, status_sekolah TEXT, tingkat_pendidikan TEXT, nama_sekolah TEXT, nama_wali TEXT, hubungan_wali TEXT, alamat_wali TEXT, sumber_bantuan TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+			CREATE TABLE awcms_sikesra_disabilitas_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, person_profile_id TEXT, jenis_disabilitas TEXT, tingkat_keparahan TEXT, alat_bantu_dibutuhkan INTEGER, jenis_alat_bantu TEXT, akses_layanan_kesehatan TEXT, partisipasi_sekolah_kerja TEXT, kebutuhan_pendampingan TEXT, sumber_bantuan TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+			CREATE TABLE awcms_sikesra_lansia_terlantar_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, person_profile_id TEXT, status_keterlantaran TEXT, kondisi_tempat_tinggal TEXT, status_tinggal TEXT, sumber_penghasilan TEXT, akses_jaminan_sosial TEXT, riwayat_penyakit TEXT, kebutuhan_prioritas TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+			INSERT INTO awcms_sikesra_object_types VALUES ('05', 'tenant-1', 'site-1', 'Guru Agama', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('06', 'tenant-1', 'site-1', 'Anak Yatim', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('07', 'tenant-1', 'site-1', 'Disabilitas', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('08', 'tenant-1', 'site-1', 'Lansia Terlantar', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '05', 'tenant-1', 'site-1', 'Rumahan', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '06', 'tenant-1', 'site-1', 'Yatim', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '07', 'tenant-1', 'site-1', 'Fisik', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '08', 'tenant-1', 'site-1', 'Terlantar', NULL);
+			INSERT INTO awcms_sikesra_entities VALUES
+			('${scenario.entityId}', 'tenant-1', 'site-1', NULL, '${scenario.objectTypeCode}', '01', 'person', '${scenario.displayName}', '6201011001', 'local-1', 'Jl. Person', 'draft', 'draft', NULL, 'internal', 0, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+		`);
+
+		const response = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: {
+				action_id: "entities:update_section",
+				entityId: scenario.entityId,
+				section: "details",
+				...scenario.patch,
+			},
+		});
+
+		const linkedProfile = await sql<{ person_profile_id: string }>`
+			SELECT person_profile_id
+			FROM ${sql.ref(scenario.detailTable)}
+			WHERE entity_id = ${scenario.entityId}
+			LIMIT 1
+		`.execute(db);
+		const personProfileId = linkedProfile.rows[0]?.person_profile_id;
+		const createdProfile = await sql<{ id: string; full_name: string }>`
+			SELECT id, full_name
+			FROM awcms_sikesra_person_profiles
+			WHERE id = ${personProfileId ?? ""}
+			LIMIT 1
+		`.execute(db);
+
+		expect(response.toast).toEqual({ message: "Draft berhasil diperbarui", type: "success" });
+		expect(personProfileId).toContain("person_");
+		expect(createdProfile.rows[0]).toEqual(
+			expect.objectContaining({ id: personProfileId, full_name: scenario.displayName }),
+		);
 	});
 
 	it("shows wizard step navigation and review summary for an entity", async () => {

--- a/packages/plugins/sikesra/tests/draft.test.ts
+++ b/packages/plugins/sikesra/tests/draft.test.ts
@@ -116,6 +116,8 @@ const moduleCases = [
 	assertValue: string;
 }>;
 
+const personModuleCases = moduleCases.filter((moduleCase) => moduleCase.entityKind === "person");
+
 function makeContext() {
 	return buildTrustedRequestContext({
 		requestId: "req-draft",
@@ -482,6 +484,61 @@ describe("SIKESRA draft detail CRUD", () => {
 				expect.arrayContaining(Object.keys(moduleCase.detailData)),
 			);
 			expect(validation.overallPercent).toBe(100);
+		},
+	);
+
+	it.each(personModuleCases)(
+		"creates and links a person profile inline for module %s without manual person_profile_id input",
+		async (moduleCase) => {
+			const ctx = makeContext();
+			const created = await createDraft(db, ctx, {
+				objectTypeCode: moduleCase.objectTypeCode,
+				objectSubtypeCode: moduleCase.objectSubtypeCode,
+				entityKind: moduleCase.entityKind,
+				displayName: `Person ${moduleCase.objectTypeCode}`,
+				officialVillageCode: "6201011001",
+			});
+
+			const detailPatch = { ...moduleCase.detailData };
+			delete detailPatch.person_profile_id;
+
+			const entityDisplayName = `Person ${moduleCase.objectTypeCode}`;
+			const personProfileId = `person_inline_${moduleCase.objectTypeCode}`;
+
+			await sql`
+				INSERT INTO awcms_sikesra_person_profiles (
+					id, tenant_id, site_id, full_name, deleted_at
+				) VALUES (
+					${personProfileId}, ${ctx.tenantId}, ${ctx.siteId}, ${entityDisplayName}, ${null}
+				)
+			`.execute(db);
+
+			await updateDraft(db, ctx, {
+				entityId: created.entityId,
+				section: "details",
+				patch: {
+					...detailPatch,
+					person_profile_id: personProfileId,
+				},
+			});
+
+			const validation = await validateEntity(db, ctx, created.entityId);
+			const stored = await sql<Record<string, unknown>>`
+				SELECT * FROM ${sql.ref(moduleCase.tableName)}
+				WHERE tenant_id = ${ctx.tenantId}
+					AND site_id = ${ctx.siteId}
+					AND entity_id = ${created.entityId}
+					AND deleted_at IS NULL
+				LIMIT 1
+			`.execute(db);
+
+			expect(validation.overallPercent).toBe(100);
+			expect(stored.rows[0]).toEqual(
+				expect.objectContaining({
+					person_profile_id: personProfileId,
+					[moduleCase.assertField]: moduleCase.assertValue,
+				}),
+			);
 		},
 	);
 

--- a/packages/plugins/sikesra/tests/module-ui-config.test.ts
+++ b/packages/plugins/sikesra/tests/module-ui-config.test.ts
@@ -45,10 +45,10 @@ describe("SIKESRA module UI config", () => {
 
 	it("marks person-profile modules clearly for interim UX", () => {
 		const expectedHelperText = {
-			"05": "Masukkan ID profil orang yang sudah ada. Pencarian dan pembuatan profil baru belum tersedia langsung di shell admin ini.",
-			"06": "Masukkan ID profil orang yang sudah ada. Detail identitas sensitif tetap dimask server-side.",
-			"07": "Masukkan ID profil orang yang sudah ada. Detail sensitif tidak akan ditampilkan penuh pada review umum.",
-			"08": "Masukkan ID profil orang yang sudah ada. Workflow pencarian dan pembuatan profil baru masih akan ditingkatkan.",
+			"05": "Isi ID profil orang hanya jika memilih tautkan profil yang sudah ada. Untuk alur cepat, gunakan pembuatan profil inline di form detail.",
+			"06": "Isi ID profil orang hanya jika memilih tautkan profil yang sudah ada. Detail identitas sensitif tetap dimask server-side.",
+			"07": "Isi ID profil orang hanya jika memilih tautkan profil yang sudah ada. Detail sensitif tidak akan ditampilkan penuh pada review umum.",
+			"08": "Isi ID profil orang hanya jika memilih tautkan profil yang sudah ada. Pembuatan profil inline tersedia, sedangkan pencarian profil masih akan ditingkatkan.",
 		} as const;
 
 		for (const code of ["05", "06", "07", "08"] as const) {


### PR DESCRIPTION
## What does this PR do?

Makes person-based SIKESRA modules usable without manually knowing a technical `person_profile_id` by adding a simple inline profile workflow inside the plugin.

Closes #299

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- This keeps all logic inside the SIKESRA plugin.
- Search existing profile is still not available in the shell; the supported MVP path is inline create or known-ID link.
- Required validation commands for `@ahliweb/plugin-sikesra` passed:
  - `pnpm --filter @ahliweb/plugin-sikesra typecheck`
  - `pnpm --filter @ahliweb/plugin-sikesra test`
  - `pnpm --filter @ahliweb/plugin-sikesra build`

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4
