### PR TITLE
feat: add stable registry cursor pagination

### DIFF
--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -1363,6 +1363,27 @@ async function buildEntityList(
 			page_action_id: "entities:view",
 			empty_text: "Tidak ada entitas",
 		});
+		if (result.nextCursor) {
+			blocks.push({
+				type: "actions",
+				elements: [
+					{
+						type: "button",
+						action_id: "entities:next_page",
+						label: "Berikutnya",
+						style: "secondary",
+						keyword: filters.keyword ?? "",
+						objectTypeCode: filters.objectTypeCode ?? "",
+						objectSubtypeCode: filters.objectSubtypeCode ?? "",
+						statusData: filters.statusData ?? "",
+						statusVerification: filters.statusVerification ?? "",
+						sensitivityLevel: filters.sensitivityLevel ?? "",
+						duplicateStatus: filters.duplicateStatus ?? "",
+						cursor: result.nextCursor,
+					},
+				],
+			});
+		}
 	}
 
 	return { blocks };
@@ -1375,6 +1396,9 @@ async function handleEntityAction(
 ): Promise<BlockResponse> {
 	const actionId = typeof action.values?.action_id === "string" ? action.values.action_id : "";
 	if (actionId === "entities:filter") {
+		return buildEntityList(db, ctx, parseEntityFilters(action.values));
+	}
+	if (actionId === "entities:next_page") {
 		return buildEntityList(db, ctx, parseEntityFilters(action.values));
 	}
 	if (actionId === "entities:start_create" || actionId === "navigate:entities/new") {
@@ -2399,6 +2423,7 @@ function parseEntityFilters(values: Record<string, unknown> | undefined): Entity
 			typeof values?.duplicateStatus === "string" && values.duplicateStatus
 				? values.duplicateStatus
 				: undefined,
+		cursor: typeof values?.cursor === "string" && values.cursor ? values.cursor : undefined,
 		sensitivityLevel:
 			typeof values?.sensitivityLevel === "string" && values.sensitivityLevel
 				? values.sensitivityLevel

--- a/packages/plugins/sikesra/src/sandbox-entry.ts
+++ b/packages/plugins/sikesra/src/sandbox-entry.ts
@@ -791,6 +791,7 @@ function normalizeEntityListInput(value: unknown) {
 		sourceInput: typeof input.sourceInput === "string" ? input.sourceInput : undefined,
 		duplicateStatus: typeof input.duplicateStatus === "string" ? input.duplicateStatus : undefined,
 		limit: typeof input.limit === "number" ? input.limit : undefined,
+		cursor: typeof input.cursor === "string" ? input.cursor : undefined,
 	};
 }
 

--- a/packages/plugins/sikesra/src/services/entities.ts
+++ b/packages/plugins/sikesra/src/services/entities.ts
@@ -29,6 +29,7 @@ export interface EntityListFilters {
 	sourceInput?: string;
 	duplicateStatus?: string;
 	limit?: number;
+	cursor?: string;
 }
 
 export interface RegionBreadcrumb {
@@ -134,6 +135,12 @@ interface EntityRow {
 
 const MAX_LIMIT = 100;
 const DEFAULT_LIMIT = 50;
+
+interface EntityListCursor {
+	updatedAt: string;
+	id: string;
+}
+
 export async function listEntities(
 	db: unknown,
 	ctx: SikesraRequestContext,
@@ -202,11 +209,38 @@ export async function listEntities(
 	const rows = result.rows;
 	const hasMore = rows.length > limit;
 	const items = rows.slice(0, limit).map((row) => mapEntitySummary(row, ctx));
+	const nextCursorRow = hasMore ? rows[limit] : undefined;
 
 	return {
 		items,
-		nextCursor: hasMore ? rows[limit]?.id : undefined,
+		nextCursor: nextCursorRow
+			? encodeEntityListCursor({ updatedAt: nextCursorRow.updated_at, id: nextCursorRow.id })
+			: undefined,
 	};
+}
+
+function encodeEntityListCursor(cursor: EntityListCursor): string {
+	return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+function decodeEntityListCursor(cursor: string): EntityListCursor | null {
+	try {
+		const parsed = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8")) as unknown;
+		if (
+			parsed &&
+			typeof parsed === "object" &&
+			!Array.isArray(parsed) &&
+			"updatedAt" in parsed &&
+			"id" in parsed &&
+			typeof parsed.updatedAt === "string" &&
+			typeof parsed.id === "string"
+		) {
+			return { updatedAt: parsed.updatedAt, id: parsed.id };
+		}
+		return null;
+	} catch {
+		return null;
+	}
 }
 
 export async function getEntityDetail(
@@ -533,6 +567,17 @@ function buildEntityWhereSql(
 	if (filters.sourceInput) conditions.push(sql`entity.source_input = ${filters.sourceInput}`);
 	if (filters.duplicateStatus) {
 		conditions.push(sql`entity.duplicate_status = ${filters.duplicateStatus}`);
+	}
+	if (filters.cursor) {
+		const cursor = decodeEntityListCursor(filters.cursor);
+		if (cursor) {
+			conditions.push(
+				sql`(
+					entity.updated_at < ${cursor.updatedAt}
+					OR (entity.updated_at = ${cursor.updatedAt} AND entity.id < ${cursor.id})
+				)`,
+			);
+		}
 	}
 	if (ctx.regionScope.villageCodes?.length) {
 		conditions.push(

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -404,6 +404,34 @@ describe("SIKESRA admin entity workflow", () => {
 		);
 	});
 
+	it("shows a next-page action that preserves registry filters when more than 50 rows exist", async () => {
+		for (let index = 0; index < 55; index++) {
+			sqlite.exec(`
+				INSERT INTO awcms_sikesra_entities VALUES
+				('entity-admin-page-${index}', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Admin Page ${index}', '6201011001', 'local-1', 'Jl. Admin ${index}', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-${String((index % 28) + 1).padStart(2, "0")}', NULL, NULL, 'admin-1', 'admin-1');
+			`);
+		}
+
+		const firstPage = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: { action_id: "entities:filter", objectTypeCode: "01", statusData: "draft" },
+		});
+		const nextButtonBlock = firstPage.blocks.find((block) => block.type === "actions" && Array.isArray(block.elements) && block.elements.some((element) => element.action_id === "entities:next_page"));
+
+		expect(nextButtonBlock).toEqual(
+			expect.objectContaining({
+				elements: expect.arrayContaining([
+					expect.objectContaining({
+						action_id: "entities:next_page",
+						objectTypeCode: "01",
+						statusData: "draft",
+						cursor: expect.any(String),
+					}),
+				]),
+			}),
+		);
+	});
+
 	it.each([
 		{
 			objectTypeCode: "05",

--- a/packages/plugins/sikesra/tests/registry.test.ts
+++ b/packages/plugins/sikesra/tests/registry.test.ts
@@ -330,4 +330,33 @@ describe("SIKESRA region and registry services", () => {
 		);
 		expect(result.items).toHaveLength(0);
 	});
+
+	it("returns a stable encoded nextCursor and next page for filtered registry lists", async () => {
+		for (let index = 0; index < 60; index++) {
+			sqlite.exec(`
+				INSERT INTO awcms_sikesra_entities VALUES
+				('entity-page-${index}', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Page ${index}', '6201011001', 'local-1', 'Jl. Page ${index}', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-${String((index % 28) + 1).padStart(2, "0")}', NULL, NULL, NULL, NULL, NULL);
+			`);
+		}
+
+		const firstPage = await listEntities(db, makeContext({ permissions: ["awcms:sikesra:entity:read"] }), {
+			objectTypeCode: "01",
+			statusData: "draft",
+			limit: 50,
+		});
+
+		const secondPage = await listEntities(db, makeContext({ permissions: ["awcms:sikesra:entity:read"] }), {
+			objectTypeCode: "01",
+			statusData: "draft",
+			limit: 50,
+			cursor: firstPage.nextCursor,
+		});
+
+		expect(firstPage.items).toHaveLength(50);
+		expect(firstPage.nextCursor).toBeTruthy();
+		expect(firstPage.nextCursor).not.toBe(firstPage.items[49]?.id);
+		expect(secondPage.items.length).toBeGreaterThan(0);
+		expect(secondPage.items.every((item) => item.objectTypeCode === "01" && item.statusData === "draft")).toBe(true);
+		expect(secondPage.items.some((item) => firstPage.items.some((first) => first.id === item.id))).toBe(false);
+	});
 });


### PR DESCRIPTION
## What does this PR do?

Completes Registry cursor pagination for SIKESRA with a stable encoded cursor based on `updated_at DESC, id DESC`, and preserves filters across the next-page admin action.

Closes #300

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- Required validation commands for `@ahliweb/plugin-sikesra` passed:
  - `pnpm --filter @ahliweb/plugin-sikesra typecheck`
  - `pnpm --filter @ahliweb/plugin-sikesra test`
  - `pnpm --filter @ahliweb/plugin-sikesra build`

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4
