### PR TITLE
fix: improve sikesra registry filter ui

### DIFF
--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -1238,21 +1238,33 @@ async function buildEntityList(
 	];
 
 	// Filter form
+	blocks.push({ type: "header", text: "Filter Daftar Data" });
+	blocks.push({
+		type: "fields",
+		fields: [
+			{ label: "Kata Kunci", value: "Cari nama atau ID entitas" },
+			{ label: "Modul Data", value: "Pilih 1 dari 8 jenis data SIKESRA" },
+			{ label: "Subjenis", value: filters.objectTypeCode ? "Pilihan subjenis mengikuti modul yang dipilih" : "Pilih modul dulu untuk memperjelas subjenis" },
+			{ label: "Status", value: "Saring berdasarkan status data, verifikasi, duplikat, dan sensitivitas" },
+		],
+	});
 	blocks.push({
 		type: "form",
 		fields: [
 			{
 				type: "text_input",
 				action_id: "keyword",
-				label: "Kata Kunci",
+				label: "Kata Kunci Pencarian",
 				placeholder: "Cari nama atau ID",
+				description: "Gunakan untuk mencari nama entitas atau ID yang sudah diketahui.",
 			},
 			{
 				type: "select",
 				action_id: "objectTypeCode",
-				label: "Modul Data",
+				label: "Filter Modul Data SIKESRA",
 				options: [{ label: "Semua Modul", value: "" }, ...moduleOptions],
 				value: filters.objectTypeCode ?? "",
+				description: "Pilih salah satu dari 8 jenis data untuk mempersempit daftar.",
 			},
 			{
 				type: "select",
@@ -1262,26 +1274,30 @@ async function buildEntityList(
 					: "Subjenis Modul (pilih modul agar lebih spesifik)",
 				options: subtypeOptions,
 				value: filters.objectSubtypeCode ?? "",
+				description: filters.objectTypeCode
+					? "Subjenis yang tampil disesuaikan dengan modul yang dipilih."
+					: "Subjenis tetap tersedia, tetapi lebih jelas jika modul data dipilih lebih dulu.",
 			},
 			{
 				type: "select",
 				action_id: "statusData",
-				label: "Status Data",
+				label: "Filter Status Data",
 				options: [
-					{ label: "Semua", value: "" },
+					{ label: "Semua Status Data", value: "" },
 					{ label: "Draft", value: "draft" },
 					{ label: "Submitted", value: "submitted" },
 					{ label: "Active", value: "active" },
 					{ label: "Archived", value: "archived" },
 				],
 				value: filters.statusData ?? "",
+				description: "Gunakan untuk membedakan data draft, diajukan, aktif, atau arsip.",
 			},
 			{
 				type: "select",
 				action_id: "statusVerification",
-				label: "Status Verifikasi",
+				label: "Filter Status Verifikasi",
 				options: [
-					{ label: "Semua", value: "" },
+					{ label: "Semua Status Verifikasi", value: "" },
 					{ label: "Draft", value: "draft" },
 					{ label: "Submitted", value: "submitted_village" },
 					{ label: "Verified", value: "verified" },
@@ -1289,34 +1305,44 @@ async function buildEntityList(
 					{ label: "Rejected", value: "rejected" },
 				],
 				value: filters.statusVerification ?? "",
+				description: "Memudahkan operator melihat data yang menunggu atau sudah selesai diverifikasi.",
 			},
 			{
 				type: "select",
 				action_id: "duplicateStatus",
-				label: "Status Duplikat",
+				label: "Filter Status Duplikat",
 				options: [
-					{ label: "Semua", value: "" },
+					{ label: "Semua Status Duplikat", value: "" },
 					{ label: "Kandidat Duplikat", value: "candidate" },
 					{ label: "Tidak Ada", value: "none" },
 					{ label: "Terkonfirmasi", value: "confirmed" },
 					{ label: "Resolved", value: "resolved" },
 				],
 				value: filters.duplicateStatus ?? "",
+				description: "Gunakan saat operator ingin fokus pada data yang perlu review duplikat.",
 			},
 			{
 				type: "select",
 				action_id: "sensitivityLevel",
-				label: "Sensitivitas",
+				label: "Filter Sensitivitas Data",
 				options: [
-					{ label: "Semua", value: "" },
+					{ label: "Semua Tingkat Sensitivitas", value: "" },
 					{ label: "Public Safe", value: "public_safe" },
 					{ label: "Internal", value: "internal" },
 					{ label: "Restricted", value: "restricted" },
 					{ label: "Highly Restricted", value: "highly_restricted" },
 				],
+				value: filters.sensitivityLevel ?? "",
+				description: "Membantu operator memisahkan data umum, internal, dan data yang lebih sensitif.",
 			},
 		],
 		submit: { label: "Filter", action_id: "entities:filter" },
+	});
+	blocks.push({
+		type: "actions",
+		elements: [
+			{ type: "button", action_id: "entities:reset_filters", label: "Reset Filter", style: "secondary" },
+		],
 	});
 
 	blocks.push({ type: "divider" });
@@ -1397,6 +1423,9 @@ async function handleEntityAction(
 	const actionId = typeof action.values?.action_id === "string" ? action.values.action_id : "";
 	if (actionId === "entities:filter") {
 		return buildEntityList(db, ctx, parseEntityFilters(action.values));
+	}
+	if (actionId === "entities:reset_filters") {
+		return buildEntityList(db, ctx, {});
 	}
 	if (actionId === "entities:next_page") {
 		return buildEntityList(db, ctx, parseEntityFilters(action.values));

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -362,10 +362,48 @@ describe("SIKESRA admin entity workflow", () => {
 		expect(registryModuleField).toEqual(
 			expect.objectContaining({
 				type: "select",
-				label: "Modul Data",
+				label: "Filter Modul Data SIKESRA",
 				options: expect.arrayContaining([
 					expect.objectContaining({ label: "Rumah Ibadah", value: "01" }),
 					expect.objectContaining({ label: "Guru Agama", value: "05" }),
+				]),
+			}),
+		);
+	});
+
+	it("renders a clearer registry filter surface with reset action", async () => {
+		const registryPage = await buildAdminPage(db, makeContext(), "/entities");
+		const filterHelp = registryPage.blocks.find((block) => block.type === "fields" && Array.isArray(block.fields) && block.fields.some((field) => field.label === "Modul Data"));
+		const filterForm = registryPage.blocks.find((block) => block.type === "form");
+		const filterFields = Array.isArray(filterForm?.fields) ? filterForm.fields : [];
+		const resetActions = registryPage.blocks.find((block) => block.type === "actions" && Array.isArray(block.elements) && block.elements.some((element) => element.action_id === "entities:reset_filters"));
+
+		expect(registryPage.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "header", text: "Filter Daftar Data" }),
+			]),
+		);
+		expect(filterHelp).toEqual(
+			expect.objectContaining({
+				fields: expect.arrayContaining([
+					expect.objectContaining({ label: "Modul Data", value: "Pilih 1 dari 8 jenis data SIKESRA" }),
+				]),
+			}),
+		);
+		expect(filterFields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ action_id: "keyword", label: "Kata Kunci Pencarian", description: expect.stringContaining("nama entitas") }),
+				expect.objectContaining({ action_id: "objectTypeCode", label: "Filter Modul Data SIKESRA", description: expect.stringContaining("8 jenis data") }),
+				expect.objectContaining({ action_id: "statusData", label: "Filter Status Data" }),
+				expect.objectContaining({ action_id: "statusVerification", label: "Filter Status Verifikasi" }),
+				expect.objectContaining({ action_id: "duplicateStatus", label: "Filter Status Duplikat" }),
+				expect.objectContaining({ action_id: "sensitivityLevel", label: "Filter Sensitivitas Data", value: "" }),
+			]),
+		);
+		expect(resetActions).toEqual(
+			expect.objectContaining({
+				elements: expect.arrayContaining([
+					expect.objectContaining({ action_id: "entities:reset_filters", label: "Reset Filter" }),
 				]),
 			}),
 		);


### PR DESCRIPTION
## What does this PR do?

Improves the SIKESRA Registry filter surface so operators can understand and use the filter controls more easily, while keeping existing filter behavior intact.

Closes #315

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- Required validation commands for `@ahliweb/plugin-sikesra` passed:
  - `pnpm --filter @ahliweb/plugin-sikesra typecheck`
  - `pnpm --filter @ahliweb/plugin-sikesra test`
  - `pnpm --filter @ahliweb/plugin-sikesra build`

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4
