### PR TITLE
feat: add dashboard entry points for sikesra modules

### DIFF
--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -146,6 +146,24 @@ async function buildDashboard(db: unknown, ctx: SikesraRequestContext): Promise<
 		text: "Gunakan halaman ini sebagai surface admin SIKESRA yang stabil selama rebuild bertahap berlangsung. Akses detail tetap harus mengikuti auth, permission, dan ABAC di backend.",
 	});
 	blocks.push({ type: "divider" });
+	blocks.push({ type: "header", text: "Kelola 8 Jenis Data SIKESRA" });
+	blocks.push({
+		type: "table",
+		columns: [
+			{ key: "module", label: "Jenis Data", format: "text" },
+			{ key: "description", label: "Deskripsi", format: "text" },
+			{ key: "actions", label: "Aksi", format: "text" },
+		],
+		rows: listModuleUiConfigs().map((moduleConfig) => ({
+			objectTypeCode: moduleConfig.objectTypeCode,
+			module: moduleConfig.label,
+			description: moduleConfig.description,
+			actions: "Input Data | Lihat Daftar",
+		})),
+		page_action_id: "dashboard:module_actions",
+		empty_text: "Tidak ada jenis data",
+	});
+	blocks.push({ type: "divider" });
 
 	// Work queues
 	if (queues.pendingVerification > 0) {
@@ -232,10 +250,37 @@ async function buildDashboard(db: unknown, ctx: SikesraRequestContext): Promise<
 }
 
 async function handleDashboardAction(
-	_db: unknown,
-	_ctx: SikesraRequestContext,
+	db: unknown,
+	ctx: SikesraRequestContext,
 	action: { type: string; values?: Record<string, unknown> },
 ): Promise<BlockResponse> {
+	const actionId = typeof action.values?.action_id === "string" ? action.values.action_id : "";
+	if (actionId === "dashboard:input_module") {
+		const objectTypeCode = typeof action.values?.objectTypeCode === "string" ? action.values.objectTypeCode : "";
+		if (objectTypeCode) return buildEntityCreateForm(db, ctx, objectTypeCode);
+	}
+	if (actionId === "dashboard:view_module") {
+		const objectTypeCode = typeof action.values?.objectTypeCode === "string" ? action.values.objectTypeCode : "";
+		if (objectTypeCode) return buildEntityList(db, ctx, { objectTypeCode });
+	}
+	if (actionId === "dashboard:module_actions") {
+		const objectTypeCode = typeof action.values?.objectTypeCode === "string" ? action.values.objectTypeCode : "";
+		if (!objectTypeCode) return { blocks: [] };
+		const moduleConfig = getModuleUiConfig(objectTypeCode);
+		return {
+			blocks: [
+				{ type: "header", text: moduleConfig?.label ?? objectTypeCode },
+				{ type: "context", text: moduleConfig?.description ?? "Pilih aksi untuk jenis data ini." },
+				{
+					type: "actions",
+					elements: [
+						{ type: "button", action_id: "dashboard:input_module", objectTypeCode, label: "Input Data", style: "primary" },
+						{ type: "button", action_id: "dashboard:view_module", objectTypeCode, label: "Lihat Daftar", style: "secondary" },
+					],
+				},
+			],
+		};
+	}
 	if (
 		action.type === "block_action" &&
 		action.values?.action_id?.toString().startsWith("navigate:")
@@ -1813,9 +1858,12 @@ function buildEntityWizardSteps(entityId?: string, activeStep = 0): Block[] {
 async function buildEntityCreateForm(
 	db: unknown,
 	ctx: SikesraRequestContext,
+	presetObjectTypeCode?: string,
 ): Promise<BlockResponse> {
 	const villages = await listOfficialRegions(db, ctx, { level: "village" });
 	const moduleConfigs = listModuleUiConfigs();
+	const presetModule = presetObjectTypeCode ? getModuleUiConfig(presetObjectTypeCode) : undefined;
+	const subtypeOptions = presetObjectTypeCode ? getModuleSubtypeOptions(presetObjectTypeCode) : getModuleSubtypeOptions();
 	return {
 		blocks: [
 			{ type: "header", text: "Wizard Buat Entitas" },
@@ -1854,12 +1902,14 @@ async function buildEntityCreateForm(
 						action_id: "objectTypeCode",
 						label: "Modul Data SIKESRA",
 						options: moduleConfigs.map((item) => ({ label: item.label, value: item.objectTypeCode })),
+						value: presetObjectTypeCode ?? "",
+						description: presetModule ? `Form ini sudah dipersiapkan untuk ${presetModule.label}.` : undefined,
 					},
 					{
 						type: "select",
 						action_id: "objectSubtypeCode",
 						label: "Subjenis Data",
-						options: getModuleSubtypeOptions(),
+						options: subtypeOptions,
 						value: "",
 					},
 					{

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -60,6 +60,69 @@ afterEach(async () => {
 });
 
 describe("SIKESRA admin entity workflow", () => {
+	it("shows the 8 data-type management section on the dashboard", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_object_types VALUES ('02', 'tenant-1', 'site-1', 'Lembaga Keagamaan', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('03', 'tenant-1', 'site-1', 'Pendidikan Keagamaan', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('04', 'tenant-1', 'site-1', 'LKS', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('05', 'tenant-1', 'site-1', 'Guru Agama', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('06', 'tenant-1', 'site-1', 'Anak Yatim', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('07', 'tenant-1', 'site-1', 'Disabilitas', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('08', 'tenant-1', 'site-1', 'Lansia Terlantar', NULL);
+		`);
+
+		const dashboard = await buildAdminPage(db, makeContext(), "/");
+		const moduleTable = dashboard.blocks.find((block) => block.type === "table" && Array.isArray(block.rows) && block.rows.some((row) => row.objectTypeCode === "01"));
+
+		expect(dashboard.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "header", text: "Kelola 8 Jenis Data SIKESRA" }),
+			]),
+		);
+		expect(moduleTable).toEqual(
+			expect.objectContaining({
+				rows: expect.arrayContaining([
+					expect.objectContaining({ objectTypeCode: "01", module: "Rumah Ibadah", actions: "Input Data | Lihat Daftar" }),
+					expect.objectContaining({ objectTypeCode: "08", module: "Lansia Terlantar", actions: "Input Data | Lihat Daftar" }),
+				]),
+			}),
+		);
+	});
+
+	it("opens a module-preset create form and a module-filtered list from the dashboard", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-dashboard-01', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Dashboard', '6201011001', 'local-1', 'Jl. Dashboard', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-dashboard-02', 'tenant-1', 'site-1', NULL, '02', '01', 'institution', 'Lembaga Dashboard', '6201011001', 'local-1', 'Jl. Dashboard 2', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-03', NULL, NULL, 'admin-1', 'admin-1');
+			INSERT INTO awcms_sikesra_object_types VALUES ('02', 'tenant-1', 'site-1', 'Lembaga Keagamaan', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '02', 'tenant-1', 'site-1', 'Islam', NULL);
+		`);
+
+		const createForm = await buildAdminPage(db, makeContext(), "/", {
+			type: "block_action",
+			values: { action_id: "dashboard:input_module", objectTypeCode: "02" },
+		});
+		const filteredList = await buildAdminPage(db, makeContext(), "/", {
+			type: "block_action",
+			values: { action_id: "dashboard:view_module", objectTypeCode: "01" },
+		});
+		const createFormBlock = createForm.blocks.find((block) => block.type === "form");
+		const createFields = Array.isArray(createFormBlock?.fields) ? createFormBlock.fields : [];
+		const listTable = filteredList.blocks.find((block) => block.type === "table");
+		const listRows = Array.isArray(listTable?.rows) ? listTable.rows : [];
+
+		expect(createFields.find((field) => field.action_id === "objectTypeCode")).toEqual(
+			expect.objectContaining({ value: "02", description: expect.stringContaining("Lembaga Keagamaan") }),
+		);
+		expect(listRows).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ displayName: "Masjid Dashboard" }),
+			]),
+		);
+		expect(listRows.some((row) => row.displayName === "Lembaga Dashboard")).toBe(false);
+	});
+
 	it("creates a draft from the admin entities page and exposes edit/archive actions", async () => {
 		const response = await buildAdminPage(db, makeContext(), "/entities", {
 			type: "form_submit",


### PR DESCRIPTION
## What does this PR do?

Adds a clear dashboard section for the 8 SIKESRA data types, with `Input Data` and `Lihat Daftar` entry points for each module.

Closes #312

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- This stays entirely inside the SIKESRA plugin.
- `Input Data` opens a module-preset create form.
- `Lihat Daftar` opens a module-filtered Registry list.
- Required validation commands for `@ahliweb/plugin-sikesra` passed:
  - `pnpm --filter @ahliweb/plugin-sikesra typecheck`
  - `pnpm --filter @ahliweb/plugin-sikesra test`
  - `pnpm --filter @ahliweb/plugin-sikesra build`

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4
