### PR TITLE
feat: add per-type sikesra list pages

### DIFF
--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -261,7 +261,7 @@ async function handleDashboardAction(
 	}
 	if (actionId === "dashboard:view_module") {
 		const objectTypeCode = typeof action.values?.objectTypeCode === "string" ? action.values.objectTypeCode : "";
-		if (objectTypeCode) return buildEntityList(db, ctx, { objectTypeCode });
+		if (objectTypeCode) return buildEntityTypeList(db, ctx, objectTypeCode, { objectTypeCode });
 	}
 	if (actionId === "dashboard:module_actions") {
 		const objectTypeCode = typeof action.values?.objectTypeCode === "string" ? action.values.objectTypeCode : "";
@@ -1460,6 +1460,62 @@ async function buildEntityList(
 	return { blocks };
 }
 
+async function buildEntityTypeList(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	objectTypeCode: string,
+	filters: EntityListFilters = {},
+): Promise<BlockResponse> {
+	const moduleConfig = getModuleUiConfig(objectTypeCode);
+	const response = await buildEntityList(db, ctx, { ...filters, objectTypeCode });
+	if (!moduleConfig) return response;
+
+	const normalizedBlocks = response.blocks.slice();
+	if (normalizedBlocks[0]?.type === "header") {
+		normalizedBlocks[0] = { type: "header", text: `Daftar ${moduleConfig.label}` };
+	}
+	if (normalizedBlocks[1]?.type === "context") {
+		normalizedBlocks[1] = {
+			type: "context",
+			text: `${moduleConfig.description} Halaman ini hanya menampilkan data untuk jenis ${moduleConfig.label}.`,
+		};
+	}
+	if (normalizedBlocks[2]?.type === "actions" && Array.isArray(normalizedBlocks[2].elements)) {
+		normalizedBlocks[2] = {
+			type: "actions",
+			elements: [
+				{
+					type: "button",
+					action_id: "entities:start_create_module",
+					objectTypeCode,
+					label: `Input Data Baru ${moduleConfig.label}`,
+					style: "primary",
+				},
+				{
+					type: "button",
+					action_id: "entities:reset_type_filters",
+					objectTypeCode,
+					label: "Reset Filter Jenis Data",
+					style: "secondary",
+				},
+			],
+		};
+	}
+
+	for (const block of normalizedBlocks) {
+		if (block.type === "actions" && Array.isArray(block.elements)) {
+			for (const element of block.elements) {
+				if (element.action_id === "entities:next_page") {
+					element.action_id = "entities:next_type_page";
+					element.objectTypeCode = objectTypeCode;
+				}
+			}
+		}
+	}
+
+	return { ...response, blocks: normalizedBlocks };
+}
+
 async function handleEntityAction(
 	db: unknown,
 	ctx: SikesraRequestContext,
@@ -1469,14 +1525,42 @@ async function handleEntityAction(
 	if (actionId === "entities:filter") {
 		return buildEntityList(db, ctx, parseEntityFilters(action.values));
 	}
+	if (actionId === "entities:view_type_list") {
+		const objectTypeCode = typeof action.values?.objectTypeCode === "string" ? action.values.objectTypeCode : "";
+		if (objectTypeCode) {
+			const filters = parseEntityFilters(action.values);
+			return buildEntityTypeList(db, ctx, objectTypeCode, {
+				...filters,
+				objectTypeCode,
+			});
+		}
+	}
 	if (actionId === "entities:reset_filters") {
 		return buildEntityList(db, ctx, {});
+	}
+	if (actionId === "entities:reset_type_filters") {
+		const objectTypeCode = typeof action.values?.objectTypeCode === "string" ? action.values.objectTypeCode : "";
+		if (objectTypeCode) return buildEntityTypeList(db, ctx, objectTypeCode, { objectTypeCode });
 	}
 	if (actionId === "entities:next_page") {
 		return buildEntityList(db, ctx, parseEntityFilters(action.values));
 	}
+	if (actionId === "entities:next_type_page") {
+		const objectTypeCode = typeof action.values?.objectTypeCode === "string" ? action.values.objectTypeCode : "";
+		if (objectTypeCode) {
+			const filters = parseEntityFilters(action.values);
+			return buildEntityTypeList(db, ctx, objectTypeCode, {
+				...filters,
+				objectTypeCode,
+			});
+		}
+	}
 	if (actionId === "entities:start_create" || actionId === "navigate:entities/new") {
 		return buildEntityCreateForm(db, ctx);
+	}
+	if (actionId === "entities:start_create_module") {
+		const objectTypeCode = typeof action.values?.objectTypeCode === "string" ? action.values.objectTypeCode : "";
+		if (objectTypeCode) return buildEntityCreateForm(db, ctx, objectTypeCode);
 	}
 	if (actionId === "entities:create_draft") {
 		const input = normalizeDraftCreateForm(action.values);

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -123,6 +123,41 @@ describe("SIKESRA admin entity workflow", () => {
 		expect(listRows.some((row) => row.displayName === "Lembaga Dashboard")).toBe(false);
 	});
 
+	it("shows a dedicated per-type list view with type-specific heading and input action", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_object_types VALUES ('04', 'tenant-1', 'site-1', 'LKS', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '04', 'tenant-1', 'site-1', 'BAZNAS', NULL);
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-lks-1', 'tenant-1', 'site-1', NULL, '04', '01', 'institution', 'LKS A', '6201011001', 'local-1', 'Jl. LKS', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-ri-1', 'tenant-1', 'site-1', NULL, '01', '01', 'building', 'Masjid Campur', '6201011001', 'local-1', 'Jl. Masjid', 'draft', 'draft', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-03', NULL, NULL, 'admin-1', 'admin-1');
+		`);
+
+		const typeList = await buildAdminPage(db, makeContext(), "/entities", {
+			type: "block_action",
+			values: { action_id: "entities:view_type_list", objectTypeCode: "04" },
+		});
+		const actionsBlock = typeList.blocks.find((block) => block.type === "actions" && Array.isArray(block.elements) && block.elements.some((element) => element.action_id === "entities:start_create_module"));
+		const tableBlock = typeList.blocks.find((block) => block.type === "table");
+		const rows = Array.isArray(tableBlock?.rows) ? tableBlock.rows : [];
+
+		expect(typeList.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "header", text: "Daftar LKS / Lembaga Kesejahteraan Sosial" }),
+				expect.objectContaining({ type: "context", text: expect.stringContaining("hanya menampilkan data") }),
+			]),
+		);
+		expect(actionsBlock).toEqual(
+			expect.objectContaining({
+				elements: expect.arrayContaining([
+					expect.objectContaining({ action_id: "entities:start_create_module", objectTypeCode: "04", label: "Input Data Baru LKS / Lembaga Kesejahteraan Sosial" }),
+				]),
+			}),
+		);
+		expect(rows).toEqual(expect.arrayContaining([expect.objectContaining({ displayName: "LKS A" })]));
+		expect(rows.some((row) => row.displayName === "Masjid Campur")).toBe(false);
+	});
+
 	it("creates a draft from the admin entities page and exposes edit/archive actions", async () => {
 		const response = await buildAdminPage(db, makeContext(), "/entities", {
 			type: "form_submit",


### PR DESCRIPTION
## What does this PR do?

Adds dedicated per-type SIKESRA list views on top of the existing Registry builder, with type-specific heading, description, filter scope, and input action.

Closes #314

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- This keeps using `listEntities()` with `objectTypeCode`, so pagination and entity detail behavior stay aligned with the existing registry contract.
- Required validation commands for `@ahliweb/plugin-sikesra` passed:
  - `pnpm --filter @ahliweb/plugin-sikesra typecheck`
  - `pnpm --filter @ahliweb/plugin-sikesra test`
  - `pnpm --filter @ahliweb/plugin-sikesra build`

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4
