### PR TITLE
feat: add per-type sikesra input forms

### DIFF
--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -1563,7 +1563,7 @@ async function handleEntityAction(
 		if (objectTypeCode) return buildEntityCreateForm(db, ctx, objectTypeCode);
 	}
 	if (actionId === "entities:create_draft") {
-		const input = normalizeDraftCreateForm(action.values);
+		const input = await normalizeDraftCreateForm(db, ctx, action.values);
 		if (
 			(input.selectedSubtypeModuleCode && input.selectedSubtypeModuleCode !== input.objectTypeCode) ||
 			(input.objectTypeCode && input.objectSubtypeCode && !hasModuleSubtype(input.objectTypeCode, input.objectSubtypeCode))
@@ -1948,20 +1948,46 @@ async function buildEntityCreateForm(
 	const moduleConfigs = listModuleUiConfigs();
 	const presetModule = presetObjectTypeCode ? getModuleUiConfig(presetObjectTypeCode) : undefined;
 	const subtypeOptions = presetObjectTypeCode ? getModuleSubtypeOptions(presetObjectTypeCode) : getModuleSubtypeOptions();
+	const createDetailFields = presetObjectTypeCode
+		? buildModuleDetailFields(presetObjectTypeCode, {}, getDetailModuleConfig(presetObjectTypeCode)?.fields ?? [])
+		: [];
+	const inlinePersonFields = presetModule?.entityKind === "person"
+		? [
+			{
+				type: "select",
+				action_id: "person_profile_mode",
+				label: "Aksi Profil Orang",
+				value: "create_inline",
+				options: [
+					{ label: "Buat profil orang dari form ini", value: "create_inline" },
+					{ label: "Tautkan profil yang sudah ada", value: "link_existing" },
+				],
+				description: "Gunakan pembuatan profil inline agar operator tidak perlu mengetahui ID teknis profil orang.",
+			},
+			{
+				type: "text_input",
+				action_id: "person_profile_full_name",
+				label: "Nama Lengkap Profil Orang",
+				placeholder: "Kosongkan untuk memakai Nama Tampilan entitas",
+				description: "Dipakai saat memilih buat profil orang dari form ini.",
+			},
+		]
+		: [];
 	return {
 		blocks: [
-			{ type: "header", text: "Wizard Buat Entitas" },
-			{ type: "context", text: "Mulai dari memilih modul data, lalu isi identitas dasar dan wilayah entitas." },
+			{ type: "header", text: presetModule ? `Input ${presetModule.label}` : "Wizard Buat Entitas" },
+			{ type: "context", text: presetModule ? `Form ini khusus untuk input ${presetModule.label}. Isi hanya field yang relevan untuk jenis data ini.` : "Mulai dari memilih modul data, lalu isi identitas dasar dan wilayah entitas." },
 			...buildEntityWizardSteps(undefined, 1),
-			{
+			...(!presetModule ? [{
 				type: "banner",
 				variant: "info",
 				title: "Catatan Untuk Modul Perorangan",
 				description: "Untuk Guru Agama, Anak Yatim, Disabilitas, dan Lansia Terlantar, siapkan Profil Orang yang sudah ada. Pencarian dan pembuatan profil baru belum tersedia langsung di shell admin ini.",
-			},
-			{ type: "divider" },
-			{ type: "header", text: "Pilihan 8 Modul Data" },
-			{
+			}, {
+				type: "divider"
+			}, {
+				type: "header", text: "Pilihan 8 Modul Data"
+			}, {
 				type: "table",
 				columns: [
 					{ key: "module", label: "Modul", format: "text" },
@@ -1976,7 +2002,7 @@ async function buildEntityCreateForm(
 					subtypes: moduleConfig.subtypes.map((item) => item.label).join(", "),
 				})),
 				empty_text: "Tidak ada modul data",
-			},
+			}] : []),
 			{ type: "divider" },
 			{
 				type: "form",
@@ -2010,6 +2036,8 @@ async function buildEntityCreateForm(
 					},
 					{ type: "text_input", action_id: "localRegionId", label: "Wilayah Lokal (Opsional)", placeholder: "Isi bila wilayah lokal sudah tersedia" },
 					{ type: "text_input", action_id: "addressText", label: "Alamat", multiline: true },
+					...inlinePersonFields,
+					...createDetailFields,
 				],
 				submit: { label: "Buat Draft", action_id: "entities:create_draft" },
 			},
@@ -2600,7 +2628,11 @@ function getActionEntityId(values: Record<string, unknown> | undefined) {
 	return undefined;
 }
 
-function normalizeDraftCreateForm(values: Record<string, unknown> | undefined): DraftCreateInput {
+async function normalizeDraftCreateForm(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	values: Record<string, unknown> | undefined,
+): Promise<DraftCreateInput> {
 	const rawObjectTypeCode = typeof values?.objectTypeCode === "string" ? values.objectTypeCode : "";
 	const rawObjectSubtypeCode = typeof values?.objectSubtypeCode === "string" ? values.objectSubtypeCode : "";
 	const selectedSubtypeModuleCode = rawObjectSubtypeCode.includes(":")
@@ -2610,6 +2642,7 @@ function normalizeDraftCreateForm(values: Record<string, unknown> | undefined): 
 		? rawObjectSubtypeCode.split(":")[1] ?? ""
 		: rawObjectSubtypeCode;
 	const moduleUi = getModuleUiConfig(rawObjectTypeCode);
+	const initialData = await normalizeDraftCreateInitialData(db, ctx, rawObjectTypeCode, values);
 	return {
 		objectTypeCode: rawObjectTypeCode,
 		objectSubtypeCode,
@@ -2619,7 +2652,74 @@ function normalizeDraftCreateForm(values: Record<string, unknown> | undefined): 
 		officialVillageCode: typeof values?.officialVillageCode === "string" ? values.officialVillageCode : "",
 		localRegionId: typeof values?.localRegionId === "string" && values.localRegionId ? values.localRegionId : undefined,
 		addressText: typeof values?.addressText === "string" && values.addressText ? values.addressText : undefined,
+		initialData,
 	};
+}
+
+async function normalizeDraftCreateInitialData(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	objectTypeCode: string,
+	values: Record<string, unknown> | undefined,
+): Promise<Record<string, unknown> | undefined> {
+	const detailModule = getDetailModuleConfig(objectTypeCode);
+	if (!detailModule) return undefined;
+
+	const initialData: Record<string, unknown> = {};
+	for (const fieldKey of detailModule.fields) {
+		if (fieldKey in (values ?? {})) {
+			initialData[fieldKey] = values?.[fieldKey];
+		}
+	}
+
+	const moduleUi = getModuleUiConfig(objectTypeCode);
+	if (moduleUi?.entityKind === "person") {
+		const prepared = await preparePersonProfileCreateData(db, ctx, values);
+		if (prepared.personProfileId) {
+			initialData.person_profile_id = prepared.personProfileId;
+		}
+	}
+
+	return Object.keys(initialData).length > 0 ? initialData : undefined;
+}
+
+async function preparePersonProfileCreateData(
+	db: unknown,
+	ctx: SikesraRequestContext,
+	values: Record<string, unknown> | undefined,
+): Promise<{ personProfileId?: string }> {
+	const mode = typeof values?.person_profile_mode === "string" ? values.person_profile_mode : "create_inline";
+	const existingProfileId = typeof values?.person_profile_id === "string" ? values.person_profile_id.trim() : "";
+	if (mode !== "create_inline") {
+		return existingProfileId ? { personProfileId: existingProfileId } : {};
+	}
+	if (existingProfileId) {
+		return { personProfileId: existingProfileId };
+	}
+
+	const fullNameRaw = typeof values?.person_profile_full_name === "string" ? values.person_profile_full_name.trim() : "";
+	const displayName = typeof values?.displayName === "string" ? values.displayName.trim() : "";
+	const fullName = fullNameRaw || displayName;
+	if (!fullName) return {};
+
+	const personProfileId = `person_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+	await sql`
+		INSERT INTO awcms_sikesra_person_profiles (
+			id,
+			tenant_id,
+			site_id,
+			full_name,
+			deleted_at
+		) VALUES (
+			${personProfileId},
+			${ctx.tenantId},
+			${ctx.siteId},
+			${fullName},
+			${null}
+		)
+	`.execute(db as never);
+
+	return { personProfileId };
 }
 
 function normalizeDraftUpdateForm(values: Record<string, unknown> | undefined): DraftUpdateInput {

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -115,6 +115,9 @@ describe("SIKESRA admin entity workflow", () => {
 		expect(createFields.find((field) => field.action_id === "objectTypeCode")).toEqual(
 			expect.objectContaining({ value: "02", description: expect.stringContaining("Lembaga Keagamaan") }),
 		);
+		expect(createFields.find((field) => field.action_id === "agama")).toEqual(
+			expect.objectContaining({ label: "Agama" }),
+		);
 		expect(listRows).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ displayName: "Masjid Dashboard" }),
@@ -156,6 +159,87 @@ describe("SIKESRA admin entity workflow", () => {
 		);
 		expect(rows).toEqual(expect.arrayContaining([expect.objectContaining({ displayName: "LKS A" })]));
 		expect(rows.some((row) => row.displayName === "Masjid Campur")).toBe(false);
+	});
+
+	it("shows a person-specific input form with inline profile fields from a module entry point", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_object_types VALUES ('05', 'tenant-1', 'site-1', 'Guru Agama', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '05', 'tenant-1', 'site-1', 'Rumahan', NULL);
+		`);
+
+		const createForm = await buildAdminPage(db, makeContext(), "/", {
+			type: "block_action",
+			values: { action_id: "dashboard:input_module", objectTypeCode: "05" },
+		});
+		const formBlock = createForm.blocks.find((block) => block.type === "form");
+		const formFields = Array.isArray(formBlock?.fields) ? formBlock.fields : [];
+
+		expect(createForm.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "header", text: "Input Guru Agama" }),
+			]),
+		);
+		expect(formFields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ action_id: "person_profile_mode", label: "Aksi Profil Orang" }),
+				expect.objectContaining({ action_id: "person_profile_full_name", label: "Nama Lengkap Profil Orang" }),
+				expect.objectContaining({ action_id: "status_guru", label: "Status Guru" }),
+			]),
+		);
+	});
+
+	it("creates institution and person module drafts from type-specific forms", async () => {
+		sqlite.exec(`
+			CREATE TABLE awcms_sikesra_lembaga_keagamaan_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, agama TEXT, nomor_sk TEXT, tanggal_sk TEXT, nama_pimpinan TEXT, jumlah_pengurus INTEGER, jumlah_anggota INTEGER, kegiatan_utama TEXT, sumber_dana TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+			CREATE TABLE awcms_sikesra_guru_agama_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, person_profile_id TEXT, agama TEXT, status_guru TEXT, bidang_pengajaran TEXT, institusi_pengajaran TEXT, jumlah_murid INTEGER, pendidikan_terakhir TEXT, sertifikasi TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+			INSERT INTO awcms_sikesra_object_types VALUES ('02', 'tenant-1', 'site-1', 'Lembaga Keagamaan', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('05', 'tenant-1', 'site-1', 'Guru Agama', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '02', 'tenant-1', 'site-1', 'Islam', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '05', 'tenant-1', 'site-1', 'Rumahan', NULL);
+		`);
+
+		await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: {
+				action_id: "entities:create_draft",
+				objectTypeCode: "02",
+				objectSubtypeCode: "02:01",
+				displayName: "Lembaga Form Khusus",
+				officialVillageCode: "6201011001",
+				agama: "Islam",
+			},
+		});
+
+		await buildAdminPage(db, makeContext(), "/entities", {
+			type: "form_submit",
+			values: {
+				action_id: "entities:create_draft",
+				objectTypeCode: "05",
+				objectSubtypeCode: "05:01",
+				displayName: "Guru Form Khusus",
+				officialVillageCode: "6201011001",
+				person_profile_mode: "create_inline",
+				person_profile_full_name: "Guru Form Khusus",
+				agama: "Islam",
+				status_guru: "aktif",
+				institusi_pengajaran: "Madrasah Form",
+			},
+		});
+
+		const institutionDetail = await sql<{ agama: string }>`
+			SELECT agama FROM awcms_sikesra_lembaga_keagamaan_details WHERE entity_id IN (
+				SELECT id FROM awcms_sikesra_entities WHERE display_name = 'Lembaga Form Khusus' LIMIT 1
+			) LIMIT 1
+		`.execute(db);
+		const personDetail = await sql<{ person_profile_id: string; status_guru: string }>`
+			SELECT person_profile_id, status_guru FROM awcms_sikesra_guru_agama_details WHERE entity_id IN (
+				SELECT id FROM awcms_sikesra_entities WHERE display_name = 'Guru Form Khusus' LIMIT 1
+			) LIMIT 1
+		`.execute(db);
+
+		expect(institutionDetail.rows[0]?.agama).toBe("Islam");
+		expect(personDetail.rows[0]?.status_guru).toBe("aktif");
+		expect(personDetail.rows[0]?.person_profile_id).toContain("person_");
 	});
 
 	it("creates a draft from the admin entities page and exposes edit/archive actions", async () => {


### PR DESCRIPTION
## What does this PR do?

Turns the module-preset create flow into real per-type SIKESRA input forms, including inline person-profile creation support for person-based modules.

Closes #313

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- This keeps the change inside the SIKESRA plugin layer only.
- Institution-style and person-style create forms are both covered.
- Required validation commands for `@ahliweb/plugin-sikesra` passed:
  - `pnpm --filter @ahliweb/plugin-sikesra typecheck`
  - `pnpm --filter @ahliweb/plugin-sikesra test`
  - `pnpm --filter @ahliweb/plugin-sikesra build`

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4
