### PR TITLE
fix: use real entity id in verification review

### DIFF
--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -3071,6 +3071,7 @@ async function buildVerificationQueue(
 		blocks.push({
 			type: "table",
 			columns: [
+				{ key: "entityId", label: "Entity ID", format: "text" },
 				{ key: "id", label: "ID SIKESRA", format: "code" },
 				{ key: "displayName", label: "Nama", format: "text" },
 				{ key: "type", label: "Tipe", format: "badge" },
@@ -3079,6 +3080,7 @@ async function buildVerificationQueue(
 				{ key: "actions", label: "Aksi", format: "text" },
 			],
 			rows: result.rows.map((row) => ({
+				entityId: row.id,
 				id: row.sikesra_id_20 ?? row.id.slice(0, 12),
 				displayName: row.display_name,
 				type: row.object_type_code,
@@ -3100,7 +3102,10 @@ async function handleVerificationAction(
 	action: { type: string; values?: Record<string, unknown> },
 ): Promise<BlockResponse> {
 	if (action.values?.action_id === "verification:review") {
-		const entityId = action.values?.id as string | undefined;
+		const entityId =
+			typeof action.values?.entityId === "string"
+				? action.values.entityId
+				: (action.values?.id as string | undefined);
 		if (entityId) {
 			return buildVerificationReview(db, ctx, entityId);
 		}

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -883,6 +883,37 @@ describe("SIKESRA admin entity workflow", () => {
 		);
 	});
 
+	it("opens the correct verification review using the real entity ID payload", async () => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-verify-1', 'tenant-1', 'site-1', '62010110010101009999', '01', '01', 'building', 'Masjid Verifikasi', '6201011001', 'local-1', 'Jl. Verify', 'draft', 'submitted_village', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+		`);
+
+		const queue = await buildAdminPage(db, makeContext(), "/verification");
+		const queueTable = queue.blocks.find((block) => block.type === "table");
+		const rows = Array.isArray(queueTable?.rows) ? queueTable.rows : [];
+		const targetRow = rows.find((row) => row.displayName === "Masjid Verifikasi");
+
+		expect(targetRow).toEqual(
+			expect.objectContaining({
+				entityId: "entity-verify-1",
+				id: "62010110010101009999",
+			}),
+		);
+
+		const review = await buildAdminPage(db, makeContext(), "/verification", {
+			type: "block_action",
+			values: { action_id: "verification:review", entityId: "entity-verify-1" },
+		});
+
+		expect(review.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "header", text: "Review: Masjid Verifikasi" }),
+				expect.objectContaining({ type: "context", text: "ID: 62010110010101009999" }),
+			]),
+		);
+	});
+
 	it("blocks submit form when high-risk duplicate readiness fails even after validation passes", async () => {
 		sqlite.exec(`
 			INSERT INTO awcms_sikesra_entities VALUES


### PR DESCRIPTION
## What does this PR do?

Fixes the SIKESRA verification queue so the `Review` action always carries and reads the real primary entity ID instead of the display ID.

Closes #309

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- Required validation commands for `@ahliweb/plugin-sikesra` passed:
  - `pnpm --filter @ahliweb/plugin-sikesra typecheck`
  - `pnpm --filter @ahliweb/plugin-sikesra test`
  - `pnpm --filter @ahliweb/plugin-sikesra build`

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4
