### PR TITLE
fix: wire verification decision submit

### DIFF
--- a/packages/plugins/sikesra/src/admin-pages.ts
+++ b/packages/plugins/sikesra/src/admin-pages.ts
@@ -47,7 +47,7 @@ import {
 	type EntityListFilters,
 } from "./services/entities.js";
 import { listLocalRegions, listOfficialRegions } from "./services/regions.js";
-import { submitForVerification } from "./services/verification.js";
+import { makeVerificationDecision, submitForVerification } from "./services/verification.js";
 import type { SikesraRequestContext } from "./security/request-context.js";
 import { guardRoute } from "./security/route-guard.js";
 import { buildTenantSiteScopeSql } from "./tenant-site-scope.js";
@@ -3101,7 +3101,8 @@ async function handleVerificationAction(
 	ctx: SikesraRequestContext,
 	action: { type: string; values?: Record<string, unknown> },
 ): Promise<BlockResponse> {
-	if (action.values?.action_id === "verification:review") {
+	const actionId = typeof action.values?.action_id === "string" ? action.values.action_id : "";
+	if (actionId === "verification:review") {
 		const entityId =
 			typeof action.values?.entityId === "string"
 				? action.values.entityId
@@ -3109,6 +3110,41 @@ async function handleVerificationAction(
 		if (entityId) {
 			return buildVerificationReview(db, ctx, entityId);
 		}
+	}
+	if (actionId === "verification:submit_decision") {
+		const entityId = typeof action.values?.entityId === "string" ? action.values.entityId : "";
+		const decision =
+			action.values?.decision === "verify" ||
+			action.values?.decision === "need_revision" ||
+			action.values?.decision === "reject"
+				? action.values.decision
+				: "verify";
+		const note = typeof action.values?.note === "string" ? action.values.note : "";
+		if (!entityId) {
+			return {
+				blocks: [
+					{ type: "banner", variant: "error", title: "Keputusan Tidak Valid", description: "Entity ID wajib ada untuk keputusan verifikasi." },
+				],
+				toast: { message: "Entity ID wajib ada untuk keputusan verifikasi", type: "error" },
+			};
+		}
+		await makeVerificationDecision(db, ctx, { entityId, decision, note });
+		const review = await buildVerificationReview(db, ctx, entityId);
+		return {
+			...review,
+			toast: {
+				message:
+					decision === "verify"
+						? "Verifikasi berhasil disimpan"
+						: decision === "reject"
+							? "Penolakan berhasil disimpan"
+							: "Permintaan revisi berhasil disimpan",
+				type: "success",
+			},
+		};
+	}
+	if (actionId === "verification:back_to_queue") {
+		return buildVerificationQueue(db, ctx);
 	}
 	return { blocks: [] };
 }

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -914,6 +914,49 @@ describe("SIKESRA admin entity workflow", () => {
 		);
 	});
 
+	it.each([
+		{ decision: "verify", expectedStatus: "verified", expectedToast: "Verifikasi berhasil disimpan" },
+		{ decision: "need_revision", expectedStatus: "needs_revision", expectedToast: "Permintaan revisi berhasil disimpan" },
+		{ decision: "reject", expectedStatus: "rejected", expectedToast: "Penolakan berhasil disimpan" },
+	])("submits verification decision '$decision' through the admin handler", async ({ decision, expectedStatus, expectedToast }) => {
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_entities VALUES
+			('entity-decision', 'tenant-1', 'site-1', '62010110010101007777', '01', '01', 'building', 'Masjid Keputusan', '6201011001', 'local-1', 'Jl. Keputusan', 'draft', 'pending_verification', NULL, 'internal', 100, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+		`);
+
+		const response = await buildAdminPage(db, makeContext(), "/verification", {
+			type: "form_submit",
+			values: {
+				action_id: "verification:submit_decision",
+				entityId: "entity-decision",
+				decision,
+				note: "Catatan verifikasi",
+			},
+		});
+		const entityRow = await sql<{ status_verification: string }>`
+			SELECT status_verification
+			FROM awcms_sikesra_entities
+			WHERE id = 'entity-decision'
+			LIMIT 1
+		`.execute(db);
+
+		expect(response.toast).toEqual({ message: expectedToast, type: "success" });
+		expect(entityRow.rows[0]?.status_verification).toBe(expectedStatus);
+	});
+
+	it("returns to the verification queue from the review screen", async () => {
+		const queue = await buildAdminPage(db, makeContext(), "/verification", {
+			type: "block_action",
+			values: { action_id: "verification:back_to_queue" },
+		});
+
+		expect(queue.blocks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "header", text: "Antrian Verifikasi" }),
+			]),
+		);
+	});
+
 	it("blocks submit form when high-risk duplicate readiness fails even after validation passes", async () => {
 		sqlite.exec(`
 			INSERT INTO awcms_sikesra_entities VALUES


### PR DESCRIPTION
## What does this PR do?

Connects the SIKESRA verification review form to `makeVerificationDecision()` so verify, need_revision, and reject decisions are persisted from the admin plugin.

Closes #310

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- Required validation commands for `@ahliweb/plugin-sikesra` passed:
  - `pnpm --filter @ahliweb/plugin-sikesra typecheck`
  - `pnpm --filter @ahliweb/plugin-sikesra test`
  - `pnpm --filter @ahliweb/plugin-sikesra build`

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4
