### PR TITLE
test: guard sikesra-only validation mode

### DIFF
--- a/demos/cloudflare/astro.config.mjs
+++ b/demos/cloudflare/astro.config.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 import cloudflare from "@astrojs/cloudflare";
 import react from "@astrojs/react";
-import { sikesraPlugin } from "@ahliweb/plugin-sikesra";
+import { isPluginEnabledForValidation, sikesraPlugin } from "@ahliweb/plugin-sikesra";
 import {
 	d1,
 	r2,
@@ -15,18 +15,13 @@ import { webhookNotifierPlugin } from "@emdash-cms/plugin-webhook-notifier";
 import { defineConfig, fontProviders } from "astro/config";
 import emdash from "emdash/astro";
 
-function isPluginEnabled(pluginId) {
-	const raw = process.env.AWCMS_ENABLED_PLUGINS ?? "";
-	const enabled = raw
-		.split(",")
-		.map((item) => item.trim())
-		.filter(Boolean);
-	if (enabled.length === 0) return true;
-	return enabled.includes(pluginId);
-}
-
-const plugins = [isPluginEnabled("sikesra") ? sikesraPlugin() : null, isPluginEnabled("forms") ? formsPlugin() : null].filter(Boolean);
-const sandboxedPlugins = [isPluginEnabled("webhook-notifier") ? webhookNotifierPlugin() : null].filter(Boolean);
+const plugins = [
+	isPluginEnabledForValidation("sikesra", process.env.AWCMS_ENABLED_PLUGINS) ? sikesraPlugin() : null,
+	isPluginEnabledForValidation("forms", process.env.AWCMS_ENABLED_PLUGINS) ? formsPlugin() : null,
+].filter(Boolean);
+const sandboxedPlugins = [
+	isPluginEnabledForValidation("webhook-notifier", process.env.AWCMS_ENABLED_PLUGINS) ? webhookNotifierPlugin() : null,
+].filter(Boolean);
 
 export default defineConfig({
 	output: "server",

--- a/demos/plugins-demo/astro.config.mjs
+++ b/demos/plugins-demo/astro.config.mjs
@@ -1,4 +1,4 @@
-import { sikesraPlugin } from "@ahliweb/plugin-sikesra";
+import { isPluginEnabledForValidation, sikesraPlugin } from "@ahliweb/plugin-sikesra";
 import cloudflare from "@astrojs/cloudflare";
 import react from "@astrojs/react";
 import { d1, r2 } from "@emdash-cms/cloudflare";
@@ -9,22 +9,12 @@ import { webhookNotifierPlugin } from "@emdash-cms/plugin-webhook-notifier";
 import { defineConfig } from "astro/config";
 import emdash from "emdash/astro";
 
-function isPluginEnabled(pluginId) {
-	const raw = process.env.AWCMS_ENABLED_PLUGINS ?? "";
-	const enabled = raw
-		.split(",")
-		.map((item) => item.trim())
-		.filter(Boolean);
-	if (enabled.length === 0) return true;
-	return enabled.includes(pluginId);
-}
-
 const plugins = [
-	isPluginEnabled("sikesra") ? sikesraPlugin() : null,
-	isPluginEnabled("audit-log") ? auditLogPlugin() : null,
-	isPluginEnabled("webhook-notifier") ? webhookNotifierPlugin() : null,
-	isPluginEnabled("embeds") ? embedsPlugin() : null,
-	isPluginEnabled("api-test") ? apiTestPlugin() : null,
+	isPluginEnabledForValidation("sikesra", process.env.AWCMS_ENABLED_PLUGINS) ? sikesraPlugin() : null,
+	isPluginEnabledForValidation("audit-log", process.env.AWCMS_ENABLED_PLUGINS) ? auditLogPlugin() : null,
+	isPluginEnabledForValidation("webhook-notifier", process.env.AWCMS_ENABLED_PLUGINS) ? webhookNotifierPlugin() : null,
+	isPluginEnabledForValidation("embeds", process.env.AWCMS_ENABLED_PLUGINS) ? embedsPlugin() : null,
+	isPluginEnabledForValidation("api-test", process.env.AWCMS_ENABLED_PLUGINS) ? apiTestPlugin() : null,
 ].filter(Boolean);
 
 export default defineConfig({

--- a/packages/plugins/sikesra/src/index.ts
+++ b/packages/plugins/sikesra/src/index.ts
@@ -27,6 +27,10 @@ import {
 	SIKESRA_API_BASE,
 	SIKESRA_ADMIN_BASE,
 } from "./shared.js";
+export {
+	isPluginEnabledForValidation,
+	parseEnabledPluginList,
+} from "./validation-mode.js";
 
 export {
 	SIKESRA_PLUGIN_ID,

--- a/packages/plugins/sikesra/src/validation-mode.ts
+++ b/packages/plugins/sikesra/src/validation-mode.ts
@@ -1,0 +1,15 @@
+export function parseEnabledPluginList(raw: string | undefined): string[] {
+	return (raw ?? "")
+		.split(",")
+		.map((item) => item.trim())
+		.filter(Boolean);
+}
+
+export function isPluginEnabledForValidation(
+	pluginId: string,
+	rawEnabledPlugins: string | undefined,
+): boolean {
+	const enabled = parseEnabledPluginList(rawEnabledPlugins);
+	if (enabled.length === 0) return true;
+	return enabled.includes(pluginId);
+}

--- a/packages/plugins/sikesra/tests/plugin.test.ts
+++ b/packages/plugins/sikesra/tests/plugin.test.ts
@@ -9,6 +9,8 @@ import {
 	SIKESRA_PLUGIN_ID,
 	SIKESRA_PUBLIC_ROUTE,
 	SIKESRA_ROUTE_NAMES,
+	isPluginEnabledForValidation,
+	parseEnabledPluginList,
 	sikesraPlugin,
 } from "../src/index.js";
 import defaultPlugin from "../src/sandbox-entry.js";
@@ -172,6 +174,26 @@ describe("sikesra sandbox shell", () => {
 
 	it("registers every expected shell route", () => {
 		expect(Object.keys(defaultPlugin.routes)).toEqual([...SIKESRA_ROUTE_NAMES]);
+	});
+
+	it("keeps only SIKESRA enabled in validation mode when AWCMS_ENABLED_PLUGINS=sikesra", () => {
+		expect(parseEnabledPluginList("sikesra")).toEqual(["sikesra"]);
+		expect(isPluginEnabledForValidation("sikesra", "sikesra")).toBe(true);
+		expect(isPluginEnabledForValidation("forms", "sikesra")).toBe(false);
+		expect(isPluginEnabledForValidation("webhook-notifier", "sikesra")).toBe(false);
+		expect(isPluginEnabledForValidation("audit-log", "sikesra")).toBe(false);
+		expect(isPluginEnabledForValidation("embeds", "sikesra")).toBe(false);
+		expect(isPluginEnabledForValidation("api-test", "sikesra")).toBe(false);
+
+		const descriptor = sikesraPlugin();
+		expect(descriptor.adminPages.map((page) => page.label)).toEqual([
+			"Dashboard",
+			"Registry",
+			"Verifikasi",
+			"Audit",
+			"Pengaturan",
+			"Operasional",
+		]);
 	});
 
 	it("renders the overview admin page through the plugin admin route", async () => {


### PR DESCRIPTION
## What does this PR do?

Adds a durable guard for SIKESRA-only validation mode by extracting the plugin-enable logic into a testable helper and asserting that non-SIKESRA plugins are excluded when `AWCMS_ENABLED_PLUGINS=sikesra`.

Closes #311

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- Includes the explicit validation run:
  - `AWCMS_ENABLED_PLUGINS=sikesra pnpm --filter @ahliweb/plugin-sikesra test`
- Also passed:
  - `pnpm --filter @ahliweb/plugin-sikesra typecheck`
  - `pnpm --filter @ahliweb/plugin-sikesra build`
- No EmDash core files were modified.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4
