### PR TITLE
fix: harden sikesra runtime guardrails

### DIFF
--- a/docs/sikesra/DEPLOYMENT.md
+++ b/docs/sikesra/DEPLOYMENT.md
@@ -43,6 +43,16 @@ This fails fast when:
 
 Replace the placeholder IDs before deployment.
 
+## SIKESRA Build
+
+Build the SIKESRA deployment with the SIKESRA-only plugin allowlist enabled:
+
+```bash
+pnpm sikesra:build
+```
+
+This is the safe production path because `AWCMS_ENABLED_PLUGINS` is consumed by `astro.config.mjs` at build time, not by the deployed Worker at request time.
+
 ## Postbuild Adapter
 
 If the host app builds an EmDash Worker into `dist/server`, patch in the repo-local wrapper with:
@@ -56,7 +66,7 @@ Environment overrides:
 - `SIKESRA_DIST_DIR` to point at a different generated server directory
 - `SIKESRA_WRAPPER_TEMPLATE` to use a different wrapper template path
 
-The wrapper template lives at `infra/sikesra/worker-wrapper-template.mjs` and keeps the `/sikesra` and SIKESRA plugin namespaces explicit without patching EmDash source packages.
+The wrapper template lives at `infra/sikesra/worker-wrapper-template.mjs` and keeps the `/sikesra` and SIKESRA plugin namespaces explicit without patching EmDash source packages. The wrapper blocks non-SIKESRA plugin routes, but it does not replace the need to build with `AWCMS_ENABLED_PLUGINS=sikesra`.
 
 ## Smoke Check
 
@@ -70,7 +80,8 @@ Optional environment variables:
 
 - `SIKESRA_BASE_URL`
 - `SIKESRA_ADMIN_PAGE`
+- `SIKESRA_ADMIN_PAGES`
 - `SIKESRA_ADMIN_COOKIE`
 - `SIKESRA_EXPECT_UNAUTHORIZED=1`
 
-This checks that `/_emdash/api/plugins/sikesra/admin` returns the expected EmDash `data.blocks` payload shape.
+By default this checks `/`, `/entities`, and `/verification` through `/_emdash/api/plugins/sikesra/admin` and fails if the response blocks do not have the expected shape.

--- a/docs/sikesra/INPUT_WORKFLOW_ISSUE_EXECUTION_ORDER.md
+++ b/docs/sikesra/INPUT_WORKFLOW_ISSUE_EXECUTION_ORDER.md
@@ -1,0 +1,59 @@
+# SIKESRA Input Workflow Issue Execution Order
+
+Use this order so each issue proves one small part of the draft input workflow before the next layer depends on it.
+
+## Rules
+
+- Do not delete upstream EmDash plugin packages.
+- Disable non-SIKESRA plugins only from the SIKESRA runtime registration path.
+- Do not modify EmDash core unless unavoidable.
+- If EmDash core is changed, document the reason, risk, and rollback path in the PR.
+
+## Order
+
+1. `#323` plugin isolation
+   Proves the SIKESRA runtime only exposes `@ahliweb/plugin-sikesra` in production/admin.
+2. `#328` migration readiness check
+   Proves the production schema has every required SIKESRA input table and key column.
+3. `#324` create-draft smoke test for all 8 modules
+   Proves each module can create one draft row and one matching detail row.
+4. `#325` module draft registry tests
+   Proves each module list shows its own draft data and excludes other modules.
+5. `#329` reopen draft from list to detail
+   Proves a newly created draft can be found in the draft list and reopened safely.
+6. `#326` wizard step navigation
+   Proves the same entity stays alive across Data Type, Region, Details, Documents, Validation, Review, and Submit.
+7. `#327` required-field validation coverage
+   Proves missing required fields are visible to operators and block code generation or verification submit.
+8. `#330` inline person profile hardening
+   Proves person modules can create or update drafts without manual `person_profile_id` handling.
+9. `#331` create-draft to submit-readiness block test
+   Proves one real module can reach review/submit readiness without unhandled exceptions.
+10. `#332` admin route smoke check
+    Proves the dashboard, entities, and verification admin routes still return valid block responses.
+11. `#333` execution-order doc
+    Proves the work can be followed by a junior programmer in a stable order.
+
+## Validation Commands
+
+Run the focused package checks first:
+
+```bash
+pnpm sikesra:build
+pnpm --filter @ahliweb/plugin-sikesra typecheck
+pnpm --filter @ahliweb/plugin-sikesra test
+```
+
+Run the route-level smoke check when the local app is up:
+
+```bash
+node scripts/sikesra-smoke-admin-route.mjs
+```
+
+Optional single-page smoke checks:
+
+```bash
+SIKESRA_ADMIN_PAGE=/ node scripts/sikesra-smoke-admin-route.mjs
+SIKESRA_ADMIN_PAGE=/entities node scripts/sikesra-smoke-admin-route.mjs
+SIKESRA_ADMIN_PAGE=/verification node scripts/sikesra-smoke-admin-route.mjs
+```

--- a/infra/sikesra/worker-wrapper-template.mjs
+++ b/infra/sikesra/worker-wrapper-template.mjs
@@ -73,6 +73,26 @@ export default {
 			return handleEmDash(request, env, ctx, "sikesra-api");
 		}
 
+		// Block non-SIKESRA plugin routes in production (#323)
+		if (
+			(pathname.startsWith("/_emdash/api/plugins/") ||
+				pathname.startsWith("/_emdash/admin/plugins/") ||
+				pathname === "/_emdash/api/admin/plugins" ||
+				pathname.startsWith("/_emdash/api/admin/plugins/")) &&
+			!pathname.startsWith("/_emdash/api/plugins/sikesra/") &&
+			!pathname.startsWith("/_emdash/admin/plugins/sikesra/") &&
+			!pathname.startsWith("/_emdash/admin/plugins/sikesra")
+		) {
+			return routeResponse(
+				JSON.stringify({ error: "Plugin not available in SIKESRA runtime" }),
+				{
+					status: 404,
+					headers: withNoStoreHeaders({ "Content-Type": "application/json; charset=utf-8" }),
+				},
+				"blocked-plugin",
+			);
+		}
+
 		try {
 			return await handleEmDash(request, env, ctx, pathname === "/" ? "emdash-root" : "emdash");
 		} catch (error) {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"locale:compile": "pnpm --filter @emdash-cms/admin locale:compile",
 		"sikesra:d1:inventory": "node scripts/sikesra-d1-overlay.mjs inventory",
 		"sikesra:d1:restore": "node scripts/sikesra-d1-overlay.mjs restore",
+		"sikesra:build": "AWCMS_ENABLED_PLUGINS=sikesra pnpm build && pnpm sikesra:postbuild",
 		"sikesra:postbuild": "node scripts/sikesra-postbuild.mjs",
 		"sikesra:verify-access": "node scripts/sikesra-verify-access.mjs",
 		"sikesra:smoke-admin": "node scripts/sikesra-smoke-admin-route.mjs",

--- a/packages/plugins/sikesra/src/index.ts
+++ b/packages/plugins/sikesra/src/index.ts
@@ -92,6 +92,10 @@ export type {
 	ReportMetadata,
 } from "./export.js";
 
+export function bundlePluginDescriptor(): PluginDescriptor {
+	return sikesraPlugin();
+}
+
 export function sikesraPlugin(): PluginDescriptor {
 	return {
 		id: SIKESRA_PLUGIN_ID,

--- a/packages/plugins/sikesra/tests/admin-pages.test.ts
+++ b/packages/plugins/sikesra/tests/admin-pages.test.ts
@@ -478,6 +478,81 @@ describe("SIKESRA admin entity workflow", () => {
 		);
 	});
 
+	it("shows operator-friendly required-field labels in validation output for all 8 modules", async () => {
+		const validationCases = [
+			{ objectTypeCode: "01", entityId: "validate-01", displayName: "Masjid Validasi", entityKind: "building", labels: ["Jenis Rumah Ibadah"] },
+			{ objectTypeCode: "02", entityId: "validate-02", displayName: "Lembaga Validasi", entityKind: "institution", labels: ["Agama"] },
+			{ objectTypeCode: "03", entityId: "validate-03", displayName: "Pendidikan Validasi", entityKind: "institution", labels: ["Jenis Pendidikan"] },
+			{ objectTypeCode: "04", entityId: "validate-04", displayName: "LKS Validasi", entityKind: "institution", labels: ["Jenis LKS"] },
+			{ objectTypeCode: "05", entityId: "validate-05", displayName: "Guru Validasi", entityKind: "person", labels: ["Profil Orang", "Agama", "Status Guru", "Institusi Pengajaran"] },
+			{ objectTypeCode: "06", entityId: "validate-06", displayName: "Anak Validasi", entityKind: "person", labels: ["Profil Orang", "Kategori Anak", "Hubungan Wali"] },
+			{ objectTypeCode: "07", entityId: "validate-07", displayName: "Disabilitas Validasi", entityKind: "person", labels: ["Profil Orang", "Jenis Disabilitas", "Tingkat Keparahan"] },
+			{ objectTypeCode: "08", entityId: "validate-08", displayName: "Lansia Validasi", entityKind: "person", labels: ["Profil Orang", "Status Keterlantaran", "Kondisi Tempat Tinggal"] },
+		] as const;
+
+		sqlite.exec(`
+			CREATE TABLE IF NOT EXISTS awcms_sikesra_lembaga_keagamaan_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, agama TEXT, nomor_sk TEXT, tanggal_sk TEXT, nama_pimpinan TEXT, jumlah_pengurus INTEGER, jumlah_anggota INTEGER, kegiatan_utama TEXT, sumber_dana TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+			CREATE TABLE IF NOT EXISTS awcms_sikesra_pendidikan_keagamaan_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, jenis_pendidikan TEXT, jumlah_santri_lk INTEGER, jumlah_santri_pr INTEGER, jumlah_guru_lk INTEGER, jumlah_guru_pr INTEGER, kurikulum TEXT, nomor_sk_operasional TEXT, status_akreditasi TEXT, sumber_dana TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+			CREATE TABLE IF NOT EXISTS awcms_sikesra_lks_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, jenis_lks TEXT, nama_pimpinan TEXT, jumlah_pengasuh INTEGER, jumlah_penerima_manfaat INTEGER, nomor_sk TEXT, tanggal_sk TEXT, sumber_dana TEXT, program_unggulan TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+			CREATE TABLE IF NOT EXISTS awcms_sikesra_guru_agama_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, person_profile_id TEXT, agama TEXT, status_guru TEXT, bidang_pengajaran TEXT, institusi_pengajaran TEXT, jumlah_murid INTEGER, pendidikan_terakhir TEXT, sertifikasi TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+			CREATE TABLE IF NOT EXISTS awcms_sikesra_anak_yatim_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, person_profile_id TEXT, kategori_anak TEXT, status_sekolah TEXT, tingkat_pendidikan TEXT, nama_sekolah TEXT, nama_wali TEXT, hubungan_wali TEXT, alamat_wali TEXT, sumber_bantuan TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+			CREATE TABLE IF NOT EXISTS awcms_sikesra_disabilitas_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, person_profile_id TEXT, jenis_disabilitas TEXT, tingkat_keparahan TEXT, alat_bantu_dibutuhkan INTEGER, jenis_alat_bantu TEXT, akses_layanan_kesehatan TEXT, partisipasi_sekolah_kerja TEXT, kebutuhan_pendampingan TEXT, sumber_bantuan TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+			CREATE TABLE IF NOT EXISTS awcms_sikesra_lansia_terlantar_details (id TEXT, tenant_id TEXT, site_id TEXT, entity_id TEXT, person_profile_id TEXT, status_keterlantaran TEXT, kondisi_tempat_tinggal TEXT, status_tinggal TEXT, sumber_penghasilan TEXT, akses_jaminan_sosial TEXT, riwayat_penyakit TEXT, kebutuhan_prioritas TEXT, created_at TEXT, updated_at TEXT, deleted_at TEXT, created_by TEXT, updated_by TEXT);
+			INSERT INTO awcms_sikesra_object_types VALUES ('02', 'tenant-1', 'site-1', 'Lembaga Keagamaan', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('03', 'tenant-1', 'site-1', 'Pendidikan Keagamaan', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('04', 'tenant-1', 'site-1', 'LKS', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('05', 'tenant-1', 'site-1', 'Guru Agama', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('06', 'tenant-1', 'site-1', 'Anak Yatim', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('07', 'tenant-1', 'site-1', 'Disabilitas', NULL);
+			INSERT INTO awcms_sikesra_object_types VALUES ('08', 'tenant-1', 'site-1', 'Lansia Terlantar', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '02', 'tenant-1', 'site-1', 'Islam', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '03', 'tenant-1', 'site-1', 'TPQ', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '04', 'tenant-1', 'site-1', 'Panti Asuhan', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '05', 'tenant-1', 'site-1', 'Guru', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '06', 'tenant-1', 'site-1', 'Yatim', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '07', 'tenant-1', 'site-1', 'Sensorik', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES ('01', '08', 'tenant-1', 'site-1', 'Terlantar', NULL);
+		`);
+
+		for (const validationCase of validationCases) {
+			sqlite.exec(`
+				INSERT INTO awcms_sikesra_entities VALUES
+				('${validationCase.entityId}', 'tenant-1', 'site-1', NULL, '${validationCase.objectTypeCode}', '01', '${validationCase.entityKind}', '${validationCase.displayName}', '6201011001', 'local-1', 'Jl. Validasi', 'draft', 'draft', NULL, 'internal', 0, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, 'admin-1', 'admin-1');
+			`);
+
+			const validation = await buildAdminPage(db, makeContext(), "/entities", {
+				type: "block_action",
+				values: { action_id: "entities:validate", entityId: validationCase.entityId },
+			});
+			const validationTable = validation.blocks.find((block) => block.type === "table");
+			const validationRows = Array.isArray(validationTable?.rows) ? validationTable.rows : [];
+			const detailRow = validationRows.find((row) => row.section === "Detail Modul");
+			const submitView = await buildAdminPage(db, makeContext(), "/entities", {
+				type: "block_action",
+				values: { action_id: "entities:open_submit", entityId: validationCase.entityId },
+			});
+
+			expect(validation.blocks).toEqual(
+				expect.arrayContaining([expect.objectContaining({ type: "header", text: "Hasil Validasi" })]),
+			);
+			expect(detailRow).toEqual(
+				expect.objectContaining({
+					valid: "no",
+					errors: expect.stringContaining(validationCase.labels[0]),
+				}),
+			);
+			for (const label of validationCase.labels) {
+				expect(detailRow?.errors).toContain(label);
+			}
+			expect(submitView.blocks).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ type: "header", text: "Ajukan Verifikasi" }),
+					expect.objectContaining({ type: "banner", title: "Belum Bisa Diajukan" }),
+				]),
+			);
+		}
+	});
+
 	it("shows a friendly required-input error for incomplete document handoff forms", async () => {
 		sqlite.exec(`
 			INSERT INTO awcms_sikesra_entities VALUES

--- a/packages/plugins/sikesra/tests/draft.test.ts
+++ b/packages/plugins/sikesra/tests/draft.test.ts
@@ -5,9 +5,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { buildTrustedRequestContext } from "../src/security/request-context.js";
 import { SIKESRA_PERMISSION_LIST } from "../src/security/permissions.js";
 import { archiveEntity, getEntityDetail, restoreEntity } from "../src/services/entities.js";
+import { getDetailModuleConfig } from "../src/detail-modules.js";
 import {
 	autosaveDraft,
 	createDraft,
+	generateSikesraId20,
 	updateDraft,
 	validateEntity,
 	type DraftCreateInput,
@@ -571,6 +573,40 @@ describe("SIKESRA draft detail CRUD", () => {
 			]),
 		);
 	});
+
+	it.each(moduleCases)(
+		"flags missing required detail fields for module %s and blocks code generation and verification submit",
+		async (moduleCase) => {
+			const ctx = makeContext();
+			const requiredFields = getDetailModuleConfig(moduleCase.objectTypeCode)?.requiredFields ?? [];
+			const created = await createDraft(db, ctx, {
+				objectTypeCode: moduleCase.objectTypeCode,
+				objectSubtypeCode: moduleCase.objectSubtypeCode,
+				entityKind: moduleCase.entityKind,
+				displayName: `Incomplete ${moduleCase.objectTypeCode}`,
+				officialVillageCode: "6201011001",
+			});
+
+			const validation = await validateEntity(db, ctx, created.entityId);
+			const detailSection = validation.sections.find((section) => section.sectionKey === "details");
+
+			expect(detailSection?.isValid).toBe(false);
+			expect(detailSection?.errors.map((error) => error.field)).toEqual(
+				expect.arrayContaining([...requiredFields]),
+			);
+			await expect(generateSikesraId20(db, ctx, created.entityId)).rejects.toThrow();
+
+			const entityRow = await sql<{ sikesra_id_20: string | null; status_verification: string }>`
+				SELECT sikesra_id_20, status_verification
+				FROM awcms_sikesra_entities
+				WHERE id = ${created.entityId}
+				LIMIT 1
+			`.execute(db);
+
+			expect(entityRow.rows[0]?.sikesra_id_20).toBeNull();
+			expect(entityRow.rows[0]?.status_verification).toBe("draft");
+		},
+	);
 
 	it("merges detail updates instead of overwriting the whole module row", async () => {
 		const ctx = makeContext();

--- a/packages/plugins/sikesra/tests/migration-check.test.ts
+++ b/packages/plugins/sikesra/tests/migration-check.test.ts
@@ -1,0 +1,175 @@
+/**
+ * #328: Production database migration check for all SIKESRA input tables.
+ *
+ * Verifies that all 10 required SIKESRA tables exist with expected key columns
+ * after running migrations. Uses in-memory SQLite to simulate D1 schema.
+ */
+import { readFileSync } from "node:fs";
+
+import Database from "better-sqlite3";
+import { Kysely, SqliteDialect, sql } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let sqlite: Database.Database;
+let db: Kysely<unknown>;
+
+const REQUIRED_TABLES = [
+	"awcms_sikesra_entities",
+	"awcms_sikesra_person_profiles",
+	"awcms_sikesra_rumah_ibadah_details",
+	"awcms_sikesra_lembaga_keagamaan_details",
+	"awcms_sikesra_pendidikan_keagamaan_details",
+	"awcms_sikesra_lks_details",
+	"awcms_sikesra_guru_agama_details",
+	"awcms_sikesra_anak_yatim_details",
+	"awcms_sikesra_disabilitas_details",
+	"awcms_sikesra_lansia_terlantar_details",
+] as const;
+
+const REQUIRED_COLUMNS: Record<string, string[]> = {
+	awcms_sikesra_entities: [
+		"id",
+		"tenant_id",
+		"site_id",
+		"object_type_code",
+		"object_subtype_code",
+		"entity_kind",
+		"display_name",
+		"official_village_code",
+		"status_data",
+		"status_verification",
+		"sensitivity_level",
+		"completeness_percent",
+	],
+	awcms_sikesra_person_profiles: ["id", "tenant_id", "site_id", "full_name", "sensitivity_level"],
+	awcms_sikesra_rumah_ibadah_details: ["id", "entity_id", "jenis_rumah_ibadah"],
+	awcms_sikesra_lembaga_keagamaan_details: ["id", "entity_id", "agama"],
+	awcms_sikesra_pendidikan_keagamaan_details: ["id", "entity_id", "jenis_pendidikan"],
+	awcms_sikesra_lks_details: ["id", "entity_id", "jenis_lks"],
+	awcms_sikesra_guru_agama_details: ["id", "entity_id", "person_profile_id", "agama", "status_guru"],
+	awcms_sikesra_anak_yatim_details: ["id", "entity_id", "person_profile_id", "kategori_anak"],
+	awcms_sikesra_disabilitas_details: ["id", "entity_id", "person_profile_id", "jenis_disabilitas"],
+	awcms_sikesra_lansia_terlantar_details: ["id", "entity_id", "person_profile_id", "status_keterlantaran"],
+};
+
+function loadMigrationSql(filename: string): string {
+	const migrationPath = new URL(`../migrations/${filename}`, import.meta.url);
+	return readFileSync(migrationPath, "utf8");
+}
+
+beforeEach(() => {
+	sqlite = new Database(":memory:");
+	db = new Kysely({ dialect: new SqliteDialect({ database: sqlite }) });
+
+	// Apply migrations 0001-0004 which create the required tables
+	const migrations = [
+		"0001_sikesra_settings_and_master.sql",
+		"0002_sikesra_regions.sql",
+		"0003_sikesra_entities_core.sql",
+		"0004_sikesra_detail_modules.sql",
+	];
+
+	for (const migration of migrations) {
+		const migrationSql = loadMigrationSql(migration);
+		// Strip BEGIN/COMMIT for SQLite in-memory execution
+		const cleaned = migrationSql
+			.replace(/^\s*BEGIN;\s*$/gm, "")
+			.replace(/^\s*COMMIT;\s*$/gm, "");
+		sqlite.exec(cleaned);
+	}
+});
+
+afterEach(async () => {
+	await db.destroy();
+	sqlite.close();
+});
+
+describe("SIKESRA production migration check (#328)", () => {
+	it("all 10 required input tables exist after migrations 0001-0004", () => {
+		const existingTables = sqlite
+			.prepare(
+				`SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'awcms_sikesra_%' ORDER BY name`,
+			)
+			.all() as { name: string }[];
+
+		const tableNames = existingTables.map((row) => row.name);
+
+		for (const required of REQUIRED_TABLES) {
+			expect(tableNames, `Missing required table: ${required}`).toContain(required);
+		}
+	});
+
+	it.each(REQUIRED_TABLES)("table %s has all required key columns", (tableName) => {
+		const columns = sqlite
+			.prepare(`PRAGMA table_info('${tableName}')`)
+			.all() as { name: string }[];
+
+		const columnNames = columns.map((col) => col.name);
+		const requiredCols = REQUIRED_COLUMNS[tableName] ?? [];
+
+		for (const col of requiredCols) {
+			expect(columnNames, `Table ${tableName} missing column: ${col}`).toContain(col);
+		}
+	});
+
+	it("entities table has correct CHECK constraints for status_data", async () => {
+		// Seed FK dependency
+		sqlite.exec(
+			`INSERT INTO awcms_sikesra_official_regions (code, tenant_id, site_id, name, level) VALUES ('6201', 't', 's', 'Test', 'village')`,
+		);
+
+		// Valid insert should succeed
+		await expect(
+			sql`INSERT INTO awcms_sikesra_entities (id, tenant_id, site_id, object_type_code, object_subtype_code, entity_kind, display_name, official_village_code, status_data, status_verification, sensitivity_level, completeness_percent, source_input) VALUES ('test-1', 't', 's', '01', '01', 'building', 'Test', '6201', 'draft', 'pending', 'internal', 0, 'manual')`.execute(
+				db,
+			),
+		).resolves.toBeDefined();
+
+		// Invalid status_data should fail
+		await expect(
+			sql`INSERT INTO awcms_sikesra_entities (id, tenant_id, site_id, object_type_code, object_subtype_code, entity_kind, display_name, official_village_code, status_data, status_verification, sensitivity_level, completeness_percent, source_input) VALUES ('test-2', 't', 's', '01', '01', 'building', 'Test', '6201', 'INVALID', 'pending', 'internal', 0, 'manual')`.execute(
+				db,
+			),
+		).rejects.toThrow();
+	});
+
+	it("migration files all have BEGIN/COMMIT wrapping", () => {
+		const migrationFiles = [
+			"0001_sikesra_settings_and_master.sql",
+			"0002_sikesra_regions.sql",
+			"0003_sikesra_entities_core.sql",
+			"0004_sikesra_detail_modules.sql",
+		];
+
+		for (const file of migrationFiles) {
+			const content = loadMigrationSql(file);
+			expect(content, `${file} missing BEGIN`).toContain("BEGIN;");
+			expect(content, `${file} missing COMMIT`).toContain("COMMIT;");
+		}
+	});
+
+	it("detail tables have entity_id foreign key column", () => {
+		const detailTables = REQUIRED_TABLES.filter((name) => name.endsWith("_details"));
+
+		for (const table of detailTables) {
+			const columns = sqlite.prepare(`PRAGMA table_info('${table}')`).all() as { name: string }[];
+			const columnNames = columns.map((col) => col.name);
+			expect(columnNames, `${table} missing entity_id`).toContain("entity_id");
+		}
+	});
+
+	it("person-linked detail tables have person_profile_id column", () => {
+		const personTables = [
+			"awcms_sikesra_guru_agama_details",
+			"awcms_sikesra_anak_yatim_details",
+			"awcms_sikesra_disabilitas_details",
+			"awcms_sikesra_lansia_terlantar_details",
+		];
+
+		for (const table of personTables) {
+			const columns = sqlite.prepare(`PRAGMA table_info('${table}')`).all() as { name: string }[];
+			const columnNames = columns.map((col) => col.name);
+			expect(columnNames, `${table} missing person_profile_id`).toContain("person_profile_id");
+		}
+	});
+});

--- a/packages/plugins/sikesra/tests/plugin.test.ts
+++ b/packages/plugins/sikesra/tests/plugin.test.ts
@@ -9,6 +9,7 @@ import {
 	SIKESRA_PLUGIN_ID,
 	SIKESRA_PUBLIC_ROUTE,
 	SIKESRA_ROUTE_NAMES,
+	bundlePluginDescriptor,
 	isPluginEnabledForValidation,
 	parseEnabledPluginList,
 	sikesraPlugin,
@@ -33,6 +34,10 @@ describe("sikesraPlugin descriptor", () => {
 			{ path: "/operations", label: "Operasional", icon: "gear" },
 		]);
 		expect(descriptor.adminWidgets).toEqual([{ id: "overview", title: "SIKESRA", size: "third" }]);
+	});
+
+	it("exports a descriptor factory for bundle validation without probing route helpers", () => {
+		expect(bundlePluginDescriptor()).toEqual(sikesraPlugin());
 	});
 
 	it("ships the governance manifest required by the canonical docs", () => {

--- a/packages/plugins/sikesra/tests/registry.test.ts
+++ b/packages/plugins/sikesra/tests/registry.test.ts
@@ -359,4 +359,60 @@ describe("SIKESRA region and registry services", () => {
 		expect(secondPage.items.every((item) => item.objectTypeCode === "01" && item.statusData === "draft")).toBe(true);
 		expect(secondPage.items.some((item) => firstPage.items.some((first) => first.id === item.id))).toBe(false);
 	});
+
+	it("returns only draft rows for the selected module across all 8 SIKESRA data types", async () => {
+		const moduleRows = [
+			{ objectTypeCode: "01", entityId: "draft-01", displayName: "Masjid Draft", entityKind: "building" },
+			{ objectTypeCode: "02", entityId: "draft-02", displayName: "Lembaga Draft", entityKind: "institution" },
+			{ objectTypeCode: "03", entityId: "draft-03", displayName: "Pendidikan Draft", entityKind: "institution" },
+			{ objectTypeCode: "04", entityId: "draft-04", displayName: "LKS Draft", entityKind: "institution" },
+			{ objectTypeCode: "05", entityId: "draft-05", displayName: "Guru Draft", entityKind: "person" },
+			{ objectTypeCode: "06", entityId: "draft-06", displayName: "Anak Draft", entityKind: "person" },
+			{ objectTypeCode: "07", entityId: "draft-07", displayName: "Disabilitas Draft", entityKind: "person" },
+			{ objectTypeCode: "08", entityId: "draft-08", displayName: "Lansia Draft", entityKind: "person" },
+		] as const;
+
+		sqlite.exec(`
+			INSERT INTO awcms_sikesra_object_types VALUES
+			('02', 'tenant-1', 'site-1', 'Lembaga Keagamaan', NULL),
+			('03', 'tenant-1', 'site-1', 'Pendidikan Keagamaan', NULL),
+			('04', 'tenant-1', 'site-1', 'LKS', NULL),
+			('05', 'tenant-1', 'site-1', 'Guru Agama', NULL),
+			('06', 'tenant-1', 'site-1', 'Anak Yatim', NULL),
+			('07', 'tenant-1', 'site-1', 'Disabilitas', NULL),
+			('08', 'tenant-1', 'site-1', 'Lansia Terlantar', NULL);
+			INSERT INTO awcms_sikesra_object_subtypes VALUES
+			('01', '02', 'tenant-1', 'site-1', 'Islam', NULL),
+			('01', '03', 'tenant-1', 'site-1', 'TPQ', NULL),
+			('01', '04', 'tenant-1', 'site-1', 'Panti Asuhan', NULL),
+			('01', '05', 'tenant-1', 'site-1', 'Guru', NULL),
+			('01', '06', 'tenant-1', 'site-1', 'Yatim', NULL),
+			('01', '07', 'tenant-1', 'site-1', 'Sensorik', NULL),
+			('01', '08', 'tenant-1', 'site-1', 'Terlantar', NULL);
+		`);
+
+		for (const moduleRow of moduleRows) {
+			sqlite.exec(`
+				INSERT INTO awcms_sikesra_entities VALUES
+				('${moduleRow.entityId}', 'tenant-1', 'site-1', NULL, '${moduleRow.objectTypeCode}', '01', '${moduleRow.entityKind}', '${moduleRow.displayName}', '6201011001', 'local-1', 'Jl. Draft', 'draft', 'draft', NULL, 'public_safe', 0, 'none', 'manual', '2026-01-01', '2026-01-02', NULL, NULL, NULL, NULL, NULL);
+			`);
+		}
+
+		for (const moduleRow of moduleRows) {
+			const result = await listEntities(
+				db,
+				makeContext({ permissions: ["awcms:sikesra:entity:read"] }),
+				{ objectTypeCode: moduleRow.objectTypeCode, statusData: "draft" },
+			);
+
+				expect(result.items).toHaveLength(1);
+				expect(result.items[0]).toEqual(
+					expect.objectContaining({
+						id: moduleRow.entityId,
+						objectTypeCode: moduleRow.objectTypeCode,
+						statusData: "draft",
+					}),
+				);
+			}
+		});
 });

--- a/packages/plugins/sikesra/tests/worker-wrapper.test.ts
+++ b/packages/plugins/sikesra/tests/worker-wrapper.test.ts
@@ -36,4 +36,46 @@ describe("sikesra worker wrapper", () => {
 		expect(response.headers.get("X-Route")).toBe("favicon");
 		await expect(response.text()).resolves.toContain("<svg");
 	});
+
+	it("blocks non-SIKESRA plugin routes in production (#323)", async () => {
+		const mod = await loadWrapperWithEntry(
+			"export default { async fetch() { return new Response('ok'); } };",
+		);
+
+		const blockedPaths = [
+			"/_emdash/api/plugins/forms/v1/status",
+			"/_emdash/api/plugins/webhook-notifier/v1/hook",
+			"/_emdash/admin/plugins/forms/",
+			"/_emdash/admin/plugins/audit-log/",
+			"/_emdash/api/admin/plugins/updates",
+			"/_emdash/api/admin/plugins/marketplace",
+			"/_emdash/api/admin/plugins/forms/disable",
+		];
+
+		for (const path of blockedPaths) {
+			const response = await mod.default.fetch(new Request(`https://example.com${path}`), {}, {});
+			expect(response.status).toBe(404);
+			expect(response.headers.get("X-Route")).toBe("blocked-plugin");
+			const body = await response.json();
+			expect(body.error).toBe("Plugin not available in SIKESRA runtime");
+		}
+	});
+
+	it("allows SIKESRA plugin routes through (#323)", async () => {
+		const mod = await loadWrapperWithEntry(
+			"export default { async fetch() { return new Response('sikesra-ok', { status: 200 }); } };",
+		);
+
+		const allowedPaths = [
+			"/_emdash/api/plugins/sikesra/v1/status",
+			"/_emdash/api/plugins/sikesra/admin",
+			"/_emdash/api/plugins/sikesra/public/metadata",
+		];
+
+		for (const path of allowedPaths) {
+			const response = await mod.default.fetch(new Request(`https://example.com${path}`), {}, {});
+			expect(response.status).toBe(200);
+			expect(response.headers.get("X-Route")).not.toBe("blocked-plugin");
+		}
+	});
 });

--- a/scripts/sikesra-smoke-admin-route.mjs
+++ b/scripts/sikesra-smoke-admin-route.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 const baseUrl = process.env.SIKESRA_BASE_URL || "http://127.0.0.1:4321";
-const page = process.env.SIKESRA_ADMIN_PAGE || "overview";
+const defaultPages = ["/", "/entities", "/verification"];
+const pages = parsePages();
 const cookie = process.env.SIKESRA_ADMIN_COOKIE || "";
 const expectUnauthorized = process.env.SIKESRA_EXPECT_UNAUTHORIZED === "1";
 
@@ -14,6 +15,61 @@ function extractBlocks(payload) {
 	return payload?.data?.blocks ?? payload?.data?.data?.blocks ?? null;
 }
 
+function parsePages() {
+	const rawPages = process.env.SIKESRA_ADMIN_PAGES || process.env.SIKESRA_ADMIN_PAGE || "";
+	const parsed = rawPages
+		.split(",")
+		.map((page) => page.trim())
+		.filter(Boolean);
+	return parsed.length > 0 ? parsed : defaultPages;
+}
+
+function assertBlockShape(blocks, page) {
+	if (!Array.isArray(blocks)) {
+		fail(`expected data.blocks array for page=${page}`);
+	}
+
+	for (const [index, block] of blocks.entries()) {
+		if (!block || typeof block !== "object" || typeof block.type !== "string") {
+			fail(
+				`invalid block response shape for page=${page} at index=${index}: ${JSON.stringify(block)}`,
+			);
+		}
+	}
+}
+
+async function smokePage(headers, page) {
+	const response = await fetch(`${baseUrl}/_emdash/api/plugins/sikesra/admin`, {
+		method: "POST",
+		headers,
+		body: JSON.stringify({ type: "page_load", page }),
+	});
+
+	const text = await response.text();
+	let payload = null;
+	try {
+		payload = JSON.parse(text);
+	} catch {
+		fail(`expected JSON response for page=${page}, received: ${text.slice(0, 200)}`);
+	}
+
+	if (expectUnauthorized) {
+		if (response.status !== 401 || payload?.error?.message !== "Authentication required") {
+			fail(`expected 401 Authentication required for page=${page}, received status=${response.status}`);
+		}
+		process.stdout.write(`[sikesra-smoke-admin-route] unauthorized path verified for page=${page}\n`);
+		return;
+	}
+
+	if (!response.ok) {
+		fail(`expected authenticated success for page=${page}, received status=${response.status}`);
+	}
+
+	const blocks = extractBlocks(payload);
+	assertBlockShape(blocks, page);
+	process.stdout.write(`[sikesra-smoke-admin-route] ok page=${page} blocks=${blocks.length}\n`);
+}
+
 async function main() {
 	const headers = {
 		"Content-Type": "application/json",
@@ -22,40 +78,9 @@ async function main() {
 
 	if (cookie) headers.Cookie = cookie;
 
-	const response = await fetch(`${baseUrl}/_emdash/api/plugins/sikesra/admin`, {
-		method: "POST",
-		headers,
-		body: JSON.stringify({ page }),
-	});
-
-	const text = await response.text();
-	let payload = null;
-	try {
-		payload = JSON.parse(text);
-	} catch {
-		fail(`expected JSON response, received: ${text.slice(0, 200)}`);
+	for (const page of pages) {
+		await smokePage(headers, page);
 	}
-
-	if (expectUnauthorized) {
-		if (response.status !== 401 || payload?.error?.message !== "Authentication required") {
-			fail(`expected 401 Authentication required, received status=${response.status}`);
-		}
-		process.stdout.write(
-			`[sikesra-smoke-admin-route] unauthorized path verified for page=${page}\n`,
-		);
-		return;
-	}
-
-	const blocks = extractBlocks(payload);
-	if (!response.ok) {
-		fail(`expected authenticated success, received status=${response.status}`);
-	}
-
-	if (!Array.isArray(blocks)) {
-		fail(`expected data.blocks array, received payload=${JSON.stringify(payload)}`);
-	}
-
-	process.stdout.write(`[sikesra-smoke-admin-route] ok page=${page} blocks=${blocks.length}\n`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## What does this PR do?

This tightens the SIKESRA-only production/runtime path and fills the remaining lightweight regression coverage around the draft input workflow.

Closes #323
Closes #325
Closes #327
Closes #328
Closes #332
Closes #333

Specifically, this PR:
- blocks non-SIKESRA plugin routes and core plugin-management API routes from the SIKESRA worker wrapper
- adds a dedicated `pnpm sikesra:build` path so the SIKESRA-only plugin allowlist is applied at build time instead of relying on Worker runtime vars
- adds a production migration readiness test for the required SIKESRA input tables and key columns
- adds draft-registry matrix coverage for all 8 SIKESRA data types
- adds required-field validation coverage for all 8 SIKESRA data types, including blocked code-generation and blocked submit flow expectations
- expands the admin route smoke script to check `/`, `/entities`, and `/verification` with stricter block-shape validation
- adds a short junior-friendly execution-order doc for the input workflow issues

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [x] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- Targeted verification run:
  - `pnpm --filter @ahliweb/plugin-sikesra typecheck`
  - `pnpm --filter @ahliweb/plugin-sikesra test`
- `pnpm lint:quick` is currently blocked by the repo's existing oxlint config error: `Rule 'prevent-abbreviations' not found in plugin 'unicorn'`.
- Full repo CI currently also reports unrelated baseline failures outside this SIKESRA plugin scope.
- I did not add a changeset because this change is limited to SIKESRA deployment/runtime guardrails, tests, scripts, and docs.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4

## Screenshots / test output

```text
pnpm --filter @ahliweb/plugin-sikesra test
Test Files  14 passed (14)
Tests  159 passed (159)

pnpm --filter @ahliweb/plugin-sikesra typecheck
passed
```
